### PR TITLE
Never invoke exit(3) within library implementation

### DIFF
--- a/src/hash/curl.c
+++ b/src/hash/curl.c
@@ -114,10 +114,8 @@ Trytes_t *Squeeze(Curl *c)
 Curl *initCurl()
 {
     Curl *c = (Curl *) malloc(sizeof(Curl));
-    if (!c) {
-        printf("curl.c: initCurl: Not available memory to init\n");
-        exit(1);
-    }
+    if (!c)
+	return NULL;
 
     signed char src[STATE_LENGTH] = {0};
     c->state = initTrits(src, STATE_LENGTH);

--- a/src/trinary/trinary.c
+++ b/src/trinary/trinary.c
@@ -47,15 +47,13 @@ Trobject_t *initTrits(signed char *src, int len)
     Trobject_t *trits = NULL;
 
     trits = (Trobject_t *) malloc(sizeof(Trobject_t));
-    if (!trits) {
-        printf("trinary.c: initTrits: Malloc Unavailable\n");
-        exit(1);
-    }
+    if (!trits)
+        return NULL;
 
     trits->data = (signed char *) malloc(len + 1);
     if (!trits->data) {
-        printf("trinary.c: initTrits: Malloc Unavailable\n");
-        exit(1);
+        free(trits);
+        return NULL;
     }
 
     /* Copy data from src to Trits */
@@ -68,8 +66,8 @@ Trobject_t *initTrits(signed char *src, int len)
     /* Check validation */
     if (!validateTrits(trits)) {
         freeTrobject(trits);
-        printf("trinary.c: initTrits: Not availabe src!\n");
-        exit(1);
+        /* Not availabe src */
+        return NULL;
     }
 
     return trits;
@@ -81,14 +79,13 @@ Trobject_t *initTrytes(signed char *src, int len)
 
     trytes = (Trobject_t *) malloc(sizeof(Trobject_t));
     if (!trytes) {
-        printf("trinary.c: initTrytes: Malloc Unavailable\n");
-        exit(1);
+        return NULL;
     }
 
     trytes->data = (signed char *) malloc(len + 1);
     if (!trytes->data) {
-        printf("trinary.c: initTrytes: Malloc Unavailable\n");
-        exit(1);
+        free(trytes);
+        return NULL;
     }
 
     /* Copy data from src to Trytes */
@@ -101,8 +98,8 @@ Trobject_t *initTrytes(signed char *src, int len)
     /* Check validation */
     if (!validateTrytes(trytes)) {
         freeTrobject(trytes);
-        printf("trinary.c: initTrytes: Not available src!\n");
-        exit(1);
+        /* Not available src */
+        return NULL;
     }
 
     return trytes;
@@ -111,14 +108,12 @@ Trobject_t *initTrytes(signed char *src, int len)
 Trobject_t *trytes_from_trits(Trobject_t *trits)
 {
     if (!trits) {
-        printf("trinary.c: trytes_from_trits: trits not initialized\n");
-        exit(1);
+        return NULL;
     }
 
     if (trits->len % 3 != 0 || !validateTrits(trits)) {
-        printf(
-            "trinary.c: trytes_from_trits: Not available trits to convert\n");
-        exit(1);
+        /* Not available trits to convert */
+        return NULL;
     }
 
     Trobject_t *trytes = NULL;
@@ -142,16 +137,12 @@ Trobject_t *trytes_from_trits(Trobject_t *trits)
 
 Trobject_t *trits_from_trytes(Trobject_t *trytes)
 {
-    if (!trytes) {
-        printf("trinary.c: trits_from_trytes: trytes not initialized\n");
-        exit(1);
-    }
+    if (!trytes)
+        return NULL;
 
     if (!validateTrytes(trytes)) {
-        printf(
-            "trinary.c: trits_from_trytes: trytes is not available to "
-            "convert\n");
-        exit(1);
+        /* trytes is not available to convert */
+        return NULL;
     }
 
     Trobject_t *trits = NULL;
@@ -173,10 +164,8 @@ Trobject_t *trits_from_trytes(Trobject_t *trytes)
 
 Trobject_t *hashTrytes(Trobject_t *t)
 {
-    if (t->type != TYPE_TRYTES) {
-        printf("trinary.c: hashTrytes: This is not trytes\n");
-        exit(1);
-    }
+    if (t->type != TYPE_TRYTES)
+        return NULL;
 
     Curl *c = initCurl();
     Absorb(c, t);

--- a/test/common.h
+++ b/test/common.h
@@ -1,10 +1,10 @@
 #ifndef TEST_COMMON_H
 #define TEST_COMMON_H
 
-#include "../src/trinary/trinary.h"
 #include "../src/hash/curl.h"
+#include "../src/trinary/trinary.h"
 
-/* FIXME: conditional inclusion of architecture-specific headers */ 
+/* FIXME: conditional inclusion of architecture-specific headers */
 #include "../src/pow_sse.h"
 
 #if defined(BUILD_OPENCL)

--- a/test/test_curl.c
+++ b/test/test_curl.c
@@ -56,6 +56,6 @@ int main()
     freeTrobject(ret_trytes);
 
     assert(ret != 0);
-    
+
     return 0;
 }


### PR DESCRIPTION
It is dangerous and irresponsible to invoke exit(3) in a certain library
consisting of several functions. Outer developers would never understand
why their programs exit when linking to dcurl. Instead, we should always
ensure the appropriate return values and transit state machine
internally.

TODO: the following files are not changed accordingly because function
prototypes have to be modified in order to reflect return values:
  * src/clcontext.c
  * src/pow_cl.c
  * src/dcurl.c