### PR TITLE
Reduce symbol exposure

### DIFF
--- a/src/dcurl.c
+++ b/src/dcurl.c
@@ -16,19 +16,19 @@ static int MAX_CPU_THREAD = -1;
 static int MAX_GPU_THREAD = -1;
 
 /* mutex protecting critical section */
-pthread_mutex_t mtx;
+static pthread_mutex_t mtx;
 
 /* Semaphore that blocks excessive task*/
-sem_t notify;
+static sem_t notify;
 
 /* check whether dcurl is initialized */
-int isInitialized = 0;
+static int isInitialized = 0;
 
 /* Respective number for Mutex */
-int *cpu_mutex_id = NULL;
-int *gpu_mutex_id = NULL;
+static int *cpu_mutex_id = NULL;
+static int *gpu_mutex_id = NULL;
 
-int get_mutex_id(int *mutex_id, int env)
+static int get_mutex_id(int *mutex_id, int env)
 {
     int MAX = (env == 1) ? MAX_CPU_THREAD : MAX_GPU_THREAD;
     for (int i = 0; i < MAX; i++) {

--- a/src/pow_sse.c
+++ b/src/pow_sse.c
@@ -41,7 +41,7 @@
 /* On Mac OS X, define our own get_nprocs_conf() */
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
-unsigned int get_nprocs_conf()
+static unsigned int get_nprocs_conf()
 {
     int numProcessors = 0;
     size_t size = sizeof(numProcessors);
@@ -52,12 +52,12 @@ unsigned int get_nprocs_conf()
 #define NPROCS
 #endif
 
-pthread_mutex_t *pow_sse_mutex;
-int *stopSSE;
-long long int *countSSE;
-int DCURL_NUM_CPU = 0;
+static pthread_mutex_t *pow_sse_mutex;
+static int *stopSSE;
+static long long int *countSSE;
+static int DCURL_NUM_CPU = 0;
 
-const int indices[] = {
+static const int indices[] = {
     0,   364, 728, 363, 727, 362, 726, 361, 725, 360, 724, 359, 723, 358, 722,
     357, 721, 356, 720, 355, 719, 354, 718, 353, 717, 352, 716, 351, 715, 350,
     714, 349, 713, 348, 712, 347, 711, 346, 710, 345, 709, 344, 708, 343, 707,


### PR DESCRIPTION
When creating an ELF shared object (by convention, a file named as
lib*.so), all symbols are marked as public, hence included in the
object's export symbol table. This commit reduces exported symbol
by marking proper 'static'.

[old]
$ size build/libdcurl.so
   text    data     bss     dec     hex filename
  16752     924     160   17836    45ac build/libdcurl.so

[new]
size build/libdcurl.so
   text    data     bss     dec     hex filename
  15936     836     168   16940    422c build/libdcurl.so

TODO: there are various way to control over symbol exports in GCC:
  * compiler flag -fvisibility=hidden
  * Using `ld' linker version script
Once we confirm consistent API naming scheme, we can then apply these
techniques.