### PR TITLE
Enforce MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2018 dcurl Developers.
+Copyright (C) 2017 IOTA AS, IOTA Foundation and Developers.
+Copyright (C) 2016 Shinya Yagyu.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ After integrating dcurl into IRI, performance of <```attachToTangle```> is measu
 * ~~Pre-compile OpenCL kernel functions and include it in dcurl.~~
 * Automatically configure dcurl after init()
 
+# Licensing
+
+`dcurl` is freely redistributable under the MIT License.
+Use of this source code is governed by a MIT-style license that can be
+found in the `LICENSE` file.
+
 # Externel Source
 * ```src/pow_sse.c``` is derived from preliminary work of Shinya Yagyu.
 * ```src/pow_cl.c``` and ```src/pow_kernel.cl``` are adopted from [iotaledger/ccurl](https://github.com/iotaledger/ccurl).

--- a/src/clcontext.c
+++ b/src/clcontext.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2018 dcurl Developers.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
+ */
+
 #include "clcontext.h"
 #include <stdio.h>
 #include "pearl.cl.h"

--- a/src/clcontext.h
+++ b/src/clcontext.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2018 dcurl Developers.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef CLCONTEXT_H_
 #define CLCONTEXT_H_
 

--- a/src/dcurl.c
+++ b/src/dcurl.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2018 dcurl Developers.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
+ */
+
 #include "dcurl.h"
 #include <pthread.h>
 #include <semaphore.h>
@@ -7,7 +13,6 @@
 #include "pow_cl.h"
 #include "pow_sse.h"
 #include "trinary/trinary.h"
-
 
 /* number of task that CPU can execute concurrently */
 static int MAX_CPU_THREAD = -1;

--- a/src/hash/curl.c
+++ b/src/hash/curl.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2018 dcurl Developers.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
+ */
+
 #include "curl.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/pow_cl.c
+++ b/src/pow_cl.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2018 dcurl Developers.
+ * Copyright (C) 2017 IOTA AS, IOTA Foundation and Developers.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
+ */
+
 #include "pow_cl.h"
 #include <CL/cl.h>
 #include <stdint.h>

--- a/src/pow_kernel.cl
+++ b/src/pow_kernel.cl
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2017 IOTA AS, IOTA Foundation and Developers.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
+ */
+
 #define HASH_LENGTH 243
 #define OFFSET_LENGTH 4
 #define NONCE_LENGTH HASH_LENGTH / 3

--- a/src/pow_sse.c
+++ b/src/pow_sse.c
@@ -1,29 +1,8 @@
 /*
- * Copyright (c) 2016, Shinya Yagyu
- * All rights reserved.
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from this
- *    software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (C) 2018 dcurl Developers.
+ * Copyright (C) 2016 Shinya Yagyu.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
  */
 
 #include "pow_sse.h"

--- a/src/trinary/trinary.c
+++ b/src/trinary/trinary.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2018 dcurl Developers.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
+ */
+
 #include "trinary.h"
 #include "../hash/curl.h"
 


### PR DESCRIPTION
Use of this source code is governed by a MIT-style license that can be
found in the `LICENSE` file.