### PR TITLE
Canonicalize build targets and allow custom config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 SRC ?= ./src
 OUT ?= ./build
-DISABLE_GPU ?= 1
-DISABLE_JNI ?= 1
 
 CFLAGS = -Os -fPIC -g
 LDFLAGS = -lpthread
+
+-include $(OUT)/local.mk
 
 # FIXME: avoid hardcoded architecture flags. We might support advanced SIMD
 # instructions for Intel and Arm later.
 CFLAGS += -msse2
 
-ifneq ("$(DISABLE_GPU)","1")
+ifeq ("$(BUILD_GPU)","1")
 include mk/opencl.mk
 endif
 
-ifneq ("$(DISABLE_JNI)","1")
+ifeq ("$(BUILD_JNI)","1")
 include mk/java.mk
 endif
 
@@ -24,7 +24,7 @@ TESTS = \
 	pow_sse \
 	multi_pow_cpu
 
-ifneq ("$(DISABLE_GPU)","1")
+ifeq ("$(BUILD_GPU)","1")
 TESTS += \
 	pow_cl \
 	multi_pow_gpu
@@ -35,7 +35,7 @@ TESTS := $(addprefix $(OUT)/test-, $(TESTS))
 LIBS = libdcurl.so
 LIBS := $(addprefix $(OUT)/, $(LIBS))
 
-all: $(TESTS) $(LIBS)
+all: config $(TESTS) $(LIBS)
 .DEFAULT_GOAL := all
 
 OBJS = \
@@ -45,13 +45,13 @@ OBJS = \
 	dcurl.o \
 	pow_sse.o
 
-ifneq ("$(DISABLE_GPU)","1")
+ifeq ("$(BUILD_GPU)","1")
 OBJS += \
 	pow_cl.o \
 	clcontext.o
 endif
 
-ifneq ("$(DISABLE_JNI)","1")
+ifeq ("$(BUILD_JNI)","1")
 OBJS += \
 	jni/iri-pearldiver-exlib.o
 endif
@@ -93,6 +93,8 @@ check: $(addsuffix .done, $(TESTS))
 
 clean:
 	$(RM) -r $(OUT)
+distclean: clean
+	$(RM) local.mk
 
 include mk/common.mk
 -include $(deps)

--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ Reference Implementation (IRI).
 * Build a shared library for IRI, generating object files in directory `build`
 * Generate JNI header file from downloading from [latest JAVA source](https://github.com/chenwei-tw/iri/tree/feat/new_pow_interface)
 ```shell
-$ make DISABLE_JNI=0
+$ make BUILD_JNI=1
 ```
+You can modify `build/local.mk` for custom build options.
 Alternatively, you can specify conditional build as following:
 ```shell
-$ make DISABLE_GPU=1 DISABLE_JNI=1
+$ make BUILD_GPU=0 BUILD_JNI=1
 ```
 
 # Test
-* Make a test with GPU
-
-```$ make check DISABLE_GPU=0```
+* Test with GPU
+```shell
+$ make BUILD_GPU=1 check
+```
 
 * Expected Results
 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -16,3 +16,10 @@ ifeq ($(UNAME_S),Darwin)
 else
 	PRINTF = env printf
 endif
+
+config: $(OUT)/config-timestamp
+
+$(OUT)/config-timestamp: $(OUT)/local.mk
+	$(Q)touch $@
+$(OUT)/local.mk:
+	$(Q)cp -f mk/defs.mk $@

--- a/mk/defs.mk
+++ b/mk/defs.mk
@@ -1,0 +1,5 @@
+# Build OpenCL backend or not
+BUILD_GPU ?= 0
+
+# Build JNI glue as the bridge between dcurl and IRI
+BUILD_JNI ?= 0


### PR DESCRIPTION
In previous commits, there are some inconsistent build targets. It is
time to unify them:
  * Inside GNU make, conditions start with `BUILD_`.
  * Inside C source files, macros start with `ENABLE_`.

`build/local.mk` can be modified in advance, and new build system would
defer it for conditional build targets.