### PR TITLE
Clean up top-level build rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-SRC ?= ./src
 OUT ?= ./build
+SRC := src
 
 CFLAGS = -Os -fPIC -g
 LDFLAGS = -lpthread
@@ -57,14 +57,11 @@ OBJS += \
 endif
 
 OBJS := $(addprefix $(OUT)/, $(OBJS))
-deps := $(OBJS:%.o=%.o.d)
-
-SHELL_HACK := $(shell mkdir -p $(OUT))
-SHELL_HACK := $(shell mkdir -p $(addprefix $(OUT)/,jni))
+#deps := $(OBJS:%.o=%.o.d)
 
 $(OUT)/test-%.o: tests/test-%.c
 	$(VECHO) "  CC\t$@\n"
-	$(Q)$(CC) -o $@ $(CFLAGS) -I src -c -MMD -MF $@.d $<
+	$(Q)$(CC) -o $@ $(CFLAGS) -I $(SRC) -c -MMD -MF $@.d $<
 
 $(OUT)/%.o: $(SRC)/%.c
 	$(VECHO) "  CC\t$@\n"
@@ -82,16 +79,6 @@ $(OUT)/test-multi_pow_%: tests/test-multi_pow_%.py $(OUT)/libdcurl.so
 	$(Q)echo "#!$(PYTHON)" > $@
 	$(call py_prepare_cmd)
 	$(Q)chmod +x $@
-
-$(OUT)/test-%.done: $(OUT)/test-%
-	$(Q)$(PRINTF) "*** Validating $< ***\n"
-	$(Q)./$< && $(PRINTF) "\t$(PASS_COLOR)[ Verified ]$(NO_COLOR)\n"
-check: $(addsuffix .done, $(TESTS))
-
-clean:
-	$(RM) -r $(OUT)
-distclean: clean
-	$(RM) local.mk
 
 include mk/common.mk
 include mk/python.mk

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -1,21 +1,32 @@
+# Always ensure directory build exist
+SHELL_HACK := $(shell mkdir -p $(OUT))
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    PRINTF = printf
+else
+    PRINTF = env printf
+endif
+
 # Control the build verbosity
 ifeq ("$(VERBOSE)","1")
     Q :=
     VECHO = @true
 else
     Q := @
-    VECHO = @printf
+    VECHO = @$(PRINTF)
 endif
 
+# dependency of source files
+deps := $(OBJS:%.o=%.o.d)
+
+# Test suite
 PASS_COLOR = \e[32;01m
 NO_COLOR = \e[0m
-
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-	PRINTF = printf
-else
-	PRINTF = env printf
-endif
+$(OUT)/test-%.done: $(OUT)/test-%
+	$(Q)$(PRINTF) "*** Validating $< ***\n"
+	$(Q)./$< && $(PRINTF) "\t$(PASS_COLOR)[ Verified ]$(NO_COLOR)\n"
+check: $(addsuffix .done, $(TESTS))
 
 config: $(OUT)/config-timestamp
 
@@ -23,3 +34,8 @@ $(OUT)/config-timestamp: $(OUT)/local.mk
 	$(Q)touch $@
 $(OUT)/local.mk:
 	$(Q)cp -f mk/defs.mk $@
+
+clean:
+	$(RM) -r $(OUT)
+distclean: clean                                                                                                                                              
+	$(RM) local.mk

--- a/mk/java.mk
+++ b/mk/java.mk
@@ -29,6 +29,7 @@ ifndef CURL
 $(error "curl is not available.")
 endif
 
+SHELL_HACK := $(shell mkdir -p $(addprefix $(OUT)/,jni))
 SHELL_HACK := $(shell mkdir -p $(OUT)/com/iota/iri/hash)
 
 GITHUB_REPO ?= chenwei-tw/iri/feat/new_pow_interface


### PR DESCRIPTION
The ideal build system is modular and extensive. Directory mk/ is used
for placeholder of various build targets and helpers.