### PR TITLE
Decouple CPU routines to dedicated header

### DIFF
--- a/src/cpu-utils.h
+++ b/src/cpu-utils.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018 dcurl Developers.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+
+/* Required for get_nprocs_conf() on Linux */
+#if defined(__linux__)
+#include <sys/sysinfo.h>
+#endif
+
+/* On Mac OS X, define our own get_nprocs_conf() */
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <sys/sysctl.h>
+static unsigned int get_nprocs_conf()
+{
+    int num_proc = 0;
+    size_t size = sizeof(num_proc);
+    if (sysctlbyname("hw.ncpu", &num_proc, &size, NULL, 0))
+        return 1;
+    return (unsigned int) num_proc;
+}
+#endif
+
+static inline int get_avail_nprocs()
+{
+    size_t nproc = get_nprocs_conf() - 1;
+
+    do {
+        char *env_ncpu = getenv("DCURL_NUM_CPU");
+        if (!env_ncpu) {
+            break;
+        }
+
+        char *end;
+        signed int num = strtol(env_ncpu, &end, 10);
+        if (end == env_ncpu) {
+            /* if no characters were converted these pointers are equal */
+            break;
+        }
+        if (errno == ERANGE || num > INT_MAX || num < 0) {
+            /* because strtol produces a long, check for overflow */
+            break;
+        }
+        nproc = num;
+    } while (0);
+
+    if (!nproc)
+        nproc = 1;
+    return nproc;
+}

--- a/src/pow_avx.c
+++ b/src/pow_avx.c
@@ -12,30 +12,11 @@
 #include "curl.h"
 #include "constants.h"
 #include <stdint.h>
-
-/* Required for get_nprocs_conf() on Linux */
-#if defined(__linux__)
-#include <sys/sysinfo.h>
-#endif
-
-/* On Mac OS X, define our own get_nprocs_conf() */
-#if defined(__APPLE__) || defined(__FreeBSD__)
-#include <sys/sysctl.h>
-static unsigned int get_nprocs_conf()
-{
-    int numProcessors = 0;
-    size_t size = sizeof(numProcessors);
-    if (sysctlbyname("hw.ncpu", &numProcessors, &size, NULL, 0))
-        return 1;
-    return (unsigned int) numProcessors;
-}
-#define NPROCS
-#endif
+#include "cpu-utils.h"
 
 static pthread_mutex_t *pow_avx_mutex;
 static int *stopAVX;
 static long long int *countAVX;
-static int DCURL_NUM_CPU = 0;
 
 static const int indices[] = {
     0,   364, 728, 363, 727, 362, 726, 361, 725, 360, 724, 359, 723, 358, 722,
@@ -351,6 +332,8 @@ static int8_t *nonce_to_result(Trytes_t *tx, Trytes_t *nonce)
     return rst;
 }
 
+static size_t nproc;
+
 int pow_avx_init(int num_task)
 {
     pow_avx_mutex =
@@ -361,11 +344,7 @@ int pow_avx_init(int num_task)
     if (!pow_avx_mutex || !stopAVX || !countAVX)
         return 0;
 
-    char *env_num_cpu = getenv("DCURL_NUM_CPU");
-    DCURL_NUM_CPU = get_nprocs_conf() - 1;
-    if (env_num_cpu) {
-        DCURL_NUM_CPU = atoi(env_num_cpu);
-    }
+    nproc = get_avail_nprocs();
     return 1;
 }
 
@@ -387,26 +366,24 @@ int8_t *PowAVX(int8_t *trytes, int mwm, int index)
     if (!c_state)
         return NULL;
 
-    int num_cpu = DCURL_NUM_CPU;
-
-    pthread_t *threads = (pthread_t *) malloc(sizeof(pthread_t) * num_cpu);
+    pthread_t *threads = (pthread_t *) malloc(sizeof(pthread_t) * nproc);
     if (!threads)
         return NULL;
 
     Pwork_struct *pitem =
-        (Pwork_struct *) malloc(sizeof(Pwork_struct) * num_cpu);
+        (Pwork_struct *) malloc(sizeof(Pwork_struct) * nproc);
     if (!pitem)
         return NULL;
 
     /* Prepare nonce to each thread */
-    int8_t **nonce_array = (int8_t **) malloc(sizeof(int8_t *) * num_cpu);
+    int8_t **nonce_array = (int8_t **) malloc(sizeof(int8_t *) * nproc);
     if (!nonce_array)
         return NULL;
 
     /* init pthread mutex */
     pthread_mutex_init(&pow_avx_mutex[index], NULL);
 
-    for (int i = 0; i < num_cpu; i++) {
+    for (int i = 0; i < nproc; i++) {
         pitem[i].mid = c_state;
         pitem[i].mwm = mwm;
         pitem[i].nonce = nonce_array[i] = (int8_t *) malloc(NonceTrinarySize);
@@ -417,7 +394,7 @@ int8_t *PowAVX(int8_t *trytes, int mwm, int index)
     }
 
     int completedIndex = -1;
-    for (int i = 0; i < num_cpu; i++) {
+    for (int i = 0; i < nproc; i++) {
         pthread_join(threads[i], NULL);
         if (pitem[i].n == -1)
             completedIndex = i;
@@ -440,7 +417,7 @@ int8_t *PowAVX(int8_t *trytes, int mwm, int index)
 
     /* Free memory */
     free(c_state);
-    for (int i = 0; i < num_cpu; i++) {
+    for (int i = 0; i < nproc; i++) {
         free(nonce_array[i]);
     }
     free(nonce_array);


### PR DESCRIPTION
atoi() is considered unsafe. Use strtol instead.

C99 standard [7.20.1] :
  The functions atof, atoi, atol, and atoll need not affect the value
  of the integer expression errno on an error. If the value of the
  result cannot be represented, the behavior is undeﬁned.