### PR TITLE
Implement cCurl-compatibile interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ OBJS += \
 	jni/iri-pearldiver-exlib.o
 endif
 
+ifeq ("$(BUILD_COMPAT)", "1")
+OBJS += \
+	compat-ccurl.o
+endif
+
 OBJS := $(addprefix $(OUT)/, $(OBJS))
 #deps := $(OBJS:%.o=%.o.d)
 

--- a/mk/defs.mk
+++ b/mk/defs.mk
@@ -6,3 +6,6 @@ BUILD_GPU ?= 0
 
 # Build JNI glue as the bridge between dcurl and IRI
 BUILD_JNI ?= 0
+
+# Build cCurl compatible interface
+BUILD_COMPAT ?= 0

--- a/src/compat-ccurl.c
+++ b/src/compat-ccurl.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 dcurl Developers.
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE file.
+ */
+
+#include "dcurl.h"
+#include <stdbool.h>
+
+static bool isInitialized = false;
+
+char *ccurl_pow(char *trytes, int mwm)
+{
+    if (!isInitialized) {
+        dcurl_init(1, 0);
+        isInitialized = true;
+    }
+    return (char *) dcurl_entry((int8_t *) trytes, mwm);
+}
+
+void ccurl_pow_finalize(void)
+{
+    dcurl_destroy();
+}
+
+void ccurl_pow_interrupt(void)
+{
+    /* Do Nothing */
+}


### PR DESCRIPTION
Once `BUILD_COMPAT` is set, cCurl-specific interface will be built
accordingly.

However, Configuration of dcurl is hardcored to [ CPU_TASK = 1,
GPU_TASK = 0 ] because IOTA wallet has no chance to compute 2 more PoW
tasks at the same time currently.

Co-authored-by: Jim Huang <jserv.tw@gmail.com>