### PR TITLE
Hide non-public symbols with LD version script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,17 @@ OUT ?= ./build
 SRC := src
 
 CFLAGS = -Wall -fPIC
-LDFLAGS = -lpthread
+LDFLAGS = \
+	-lpthread
+
+UNAME_S := $(shell uname -s)
+ifneq ($(UNAME_S),Darwin)
+# GNU ld specific options
+LDFLAGS += \
+	-Wl,--gc-sections \
+	-Wl,--as-needed \
+	-Wl,--version-script=./mk/libdcurl.version
+endif
 
 -include $(OUT)/local.mk
 

--- a/mk/libdcurl.version
+++ b/mk/libdcurl.version
@@ -1,0 +1,14 @@
+CODEABI_1.0 {
+    global:
+        /* core */
+        dcurl_*;
+
+        /* compat */
+        ccurl_*;
+
+        /* JNI */
+        Java_com_iota_iri_hash_PearlDiver*;
+
+    local: *;
+};
+


### PR DESCRIPTION
Version scripts provides information that can be used by GNU/Linux
distribution packaging tools. For example, Debian has a tool
dpkg-shlibdeps that can determine the minimal required version of each
dependency (by looking at the symbol list) and stuff the information
into the Debian specific packaging files.

We can utilize such feasture to reduce the size of shared library as
well.

[orig]
$ size build/libdcurl.so
   text    data     bss     dec     hex filename
  16836     840     168   17844    45b4 build/libdcurl.so

[LD-version-script]
$ size build/libdcurl.so
   text    data     bss     dec     hex filename
  15472     760     168   16400    4010 build/libdcurl.so