### PR TITLE
Improve SSE-specific configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SSE_S := $(shell grep -o sse /proc/cpuinfo | head -n 1)
 ifeq ("$(BUILD_AVX)","1")
 CFLAGS += -mavx -mavx2 -DENABLE_AVX
 else
-ifeq ($(SSE_S),sse)
+ifeq ("$(BUILD_SSE)"_$(SSE_S),"1"_sse)
 CFLAGS += -msse2 -DENABLE_SSE
 endif
 endif
@@ -52,7 +52,7 @@ TESTS += \
 	pow_avx \
 	multi_pow_cpu
 else
-ifeq ($(SSE_S),sse)
+ifeq ("$(BUILD_SSE)"_$(SSE_S),"1"_sse)
 TESTS += \
 	pow_sse \
 	multi_pow_cpu
@@ -90,7 +90,7 @@ OBJS = \
 ifeq ("$(BUILD_AVX)","1")
 OBJS += pow_avx.o
 else
-ifeq ($(SSE_S),sse)
+ifeq ("$(BUILD_SSE)"_$(SSE_S),"1"_sse)
 OBJS += pow_sse.o
 else
 OBJS += pow_c.o


### PR DESCRIPTION
To build a environment of cross compiling, we need improve SSE-specific configuration. In a environment with SSE, the SSE PoW solution always is enabled and we can not build another implemented PoW solutions with C language.