### PR TITLE
Integrate with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+
+compiler:
+  - clang
+  - gcc
+
+script:
+  - make

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OUT ?= ./build
 SRC := src
 
-CFLAGS = -Wall -fPIC
+CFLAGS = -Wall -fPIC -std=c99
 LDFLAGS = \
 	-lpthread
 


### PR DESCRIPTION
To prevent the potential conflicts, integrate Travis CI to build the
code when the code base changes.

Since we are writing code in C99 standard, it is required to add the
'-std=c99' to the CFLAGS in Makefile.