### PR TITLE
Check specific CPU features for build environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,14 @@ else
 CFLAGS += -Ofast
 endif
 
-SSE_S := $(shell grep -o sse /proc/cpuinfo | head -n 1)
+# Check specific CPU features available on build host
+include mk/cpu-features.mk
 
-# FIXME: avoid hardcoded architecture flags. We might support advanced SIMD
-# instructions for Intel and Arm later.
 ifeq ("$(BUILD_AVX)","1")
 CFLAGS += -mavx -mavx2 -DENABLE_AVX
 else
-ifeq ("$(BUILD_SSE)"_$(SSE_S),"1"_sse)
+BUILD_SSE := $(call cpu_feature,SSE)
+ifeq ("$(BUILD_SSE)","1")
 CFLAGS += -msse2 -DENABLE_SSE
 endif
 endif
@@ -52,7 +52,7 @@ TESTS += \
 	pow_avx \
 	multi_pow_cpu
 else
-ifeq ("$(BUILD_SSE)"_$(SSE_S),"1"_sse)
+ifeq ("$(BUILD_SSE)","1")
 TESTS += \
 	pow_sse \
 	multi_pow_cpu
@@ -90,7 +90,7 @@ OBJS = \
 ifeq ("$(BUILD_AVX)","1")
 OBJS += pow_avx.o
 else
-ifeq ("$(BUILD_SSE)"_$(SSE_S),"1"_sse)
+ifeq ("$(BUILD_SSE)","1")
 OBJS += pow_sse.o
 else
 OBJS += pow_c.o

--- a/mk/cpu-features.mk
+++ b/mk/cpu-features.mk
@@ -1,0 +1,10 @@
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+# macOS
+FEATURES := sysctl machdep.cpu.features
+else
+# Linux
+FEATURES := cat /proc/cpuinfo
+endif
+
+cpu_feature = $(shell $(FEATURES) | grep -oi $1 >/dev/null && echo 1 || echo 0)


### PR DESCRIPTION
By default, CPU extensions such as NEON and AVX are disabled, and
the use of SSE is part of the x86_64 ABI. The change introduced new
macro to detect CPU features on both Linux and macOS.