### PR TITLE
Fix issue #61

### DIFF
--- a/src/pow_fpga_accel.c
+++ b/src/pow_fpga_accel.c
@@ -54,11 +54,11 @@ static bool PoWFPGAAccel(void *pow_ctx)
     Trits_t *object_trits = trits_from_trytes(object_trytes);
     if (!object_trits)
         return false;
-    
-    lseek(ctx->in_fd,0,0);
-    lseek(ctx->ctrl_fd,0,0);
-    lseek(ctx->out_fd,0,0);
-    
+
+    lseek(ctx->in_fd, 0, 0);
+    lseek(ctx->ctrl_fd, 0, 0);
+    lseek(ctx->out_fd, 0, 0);
+
     if (write(ctx->in_fd, (char *) object_trits->data, transactionTrinarySize) <
         0)
         return false;

--- a/src/pow_fpga_accel.c
+++ b/src/pow_fpga_accel.c
@@ -54,7 +54,11 @@ static bool PoWFPGAAccel(void *pow_ctx)
     Trits_t *object_trits = trits_from_trytes(object_trytes);
     if (!object_trits)
         return false;
-
+    
+    lseek(ctx->in_fd,0,0);
+    lseek(ctx->ctrl_fd,0,0);
+    lseek(ctx->out_fd,0,0);
+    
     if (write(ctx->in_fd, (char *) object_trits->data, transactionTrinarySize) <
         0)
         return false;


### PR DESCRIPTION
This issue is caused by the automatically performed adjustment
of the file offset by using low-level I/O. It leads the file
offset to be not correct when reentering the PoWFPGAAccel function
to execute low-level I/O. Therefore, it needs to reset file offset.
Close #61