### PR TITLE
Fix build issue in pow_avx.h

### DIFF
--- a/src/pow_avx.h
+++ b/src/pow_avx.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <pthread.h>
-#include <constants.h>
+#include "constants.h"
 
 typedef struct _pwork_struct Pwork_struct;
 


### PR DESCRIPTION
In the end just a typo - but preventing to build the AVX enabled version.