### PR TITLE
Rename and add the constant-related macros

### DIFF
--- a/src/clcontext.c
+++ b/src/clcontext.c
@@ -119,15 +119,15 @@ static bool init_cl_buffer(CLContext *ctx)
 static bool init_BufferInfo(CLContext *ctx)
 {
     ctx->kernel_info.buffer_info[INDEX_OF_TRIT_HASH] =
-        (BufferInfo){sizeof(char) * HASH_LENGTH, CL_MEM_WRITE_ONLY};
+        (BufferInfo){sizeof(char) * HASH_TRITS_LENGTH, CL_MEM_WRITE_ONLY};
     ctx->kernel_info.buffer_info[INDEX_OF_MID_LOW] =
-        (BufferInfo){sizeof(int64_t) * STATE_LENGTH, CL_MEM_READ_WRITE, 2};
+        (BufferInfo){sizeof(int64_t) * STATE_TRITS_LENGTH, CL_MEM_READ_WRITE, 2};
     ctx->kernel_info.buffer_info[INDEX_OF_MID_HIGH] =
-        (BufferInfo){sizeof(int64_t) * STATE_LENGTH, CL_MEM_READ_WRITE, 2};
+        (BufferInfo){sizeof(int64_t) * STATE_TRITS_LENGTH, CL_MEM_READ_WRITE, 2};
     ctx->kernel_info.buffer_info[INDEX_OF_STATE_LOW] =
-        (BufferInfo){sizeof(int64_t) * STATE_LENGTH, CL_MEM_READ_WRITE, 2};
+        (BufferInfo){sizeof(int64_t) * STATE_TRITS_LENGTH, CL_MEM_READ_WRITE, 2};
     ctx->kernel_info.buffer_info[INDEX_OF_STATE_HIGH] =
-        (BufferInfo){sizeof(int64_t) * STATE_LENGTH, CL_MEM_READ_WRITE, 2};
+        (BufferInfo){sizeof(int64_t) * STATE_TRITS_LENGTH, CL_MEM_READ_WRITE, 2};
     ctx->kernel_info.buffer_info[INDEX_OF_MWM] =
         (BufferInfo){sizeof(size_t), CL_MEM_READ_ONLY};
     ctx->kernel_info.buffer_info[INDEX_OF_FOUND] =

--- a/src/constants.h
+++ b/src/constants.h
@@ -8,12 +8,15 @@
 #define Depth 3
 #define Radix 3
 
+#define HASH_TRYTES_LENGTH 81
+#define NONCE_TRYTES_LENGTH 27
+#define STATE_TRYTES_LENGTH 3 * HASH_TRYTES_LENGTH
 #define TRANSACTION_TRYTES_LENGTH 2673
 
-#define HASH_LENGTH 243                                      // trits
-#define NONCE_LENGTH 81                                      // trits
-#define STATE_LENGTH 3 * HASH_LENGTH                         // trits
-#define TRANSACTION_LENGTH (TRANSACTION_TRYTES_LENGTH * 3)   // trits
+#define HASH_TRITS_LENGTH 243
+#define NONCE_TRITS_LENGTH 81
+#define STATE_TRITS_LENGTH 3 * HASH_TRITS_LENGTH
+#define TRANSACTION_TRITS_LENGTH (TRANSACTION_TRYTES_LENGTH * 3)
 
 #define SignatureMessageFragmentTrinaryOffset 0
 #define SignatureMessageFragmentTrinarySize 6561

--- a/src/curl.c
+++ b/src/curl.c
@@ -64,10 +64,10 @@ static const int indices__[] = {
 static void _transform(int8_t state[])
 {
     int r = 0, i = 0;
-    int8_t copy[STATE_LENGTH] = {0};
+    int8_t copy[STATE_TRITS_LENGTH] = {0};
     int8_t *from = state, *to = copy;
     for (r = 0; r < 81; r++) {
-        for (i = 0; i < STATE_LENGTH; i++) {
+        for (i = 0; i < STATE_TRITS_LENGTH; i++) {
             int aa = indices__[i];
             int bb = indices__[i + 1];
             to[i] = truthTable[from[aa] + (from[bb] << 2) + 5];
@@ -76,7 +76,7 @@ static void _transform(int8_t state[])
         from = to;
         to = tmp;
     }
-    memcpy(state, copy, STATE_LENGTH);
+    memcpy(state, copy, STATE_TRITS_LENGTH);
 }
 
 void Transform(Curl *c)
@@ -104,12 +104,12 @@ void Absorb(Curl *c, Trytes_t *inn)
 
 Trytes_t *Squeeze(Curl *c)
 {
-    int8_t src[HASH_LENGTH] = {0};
+    int8_t src[HASH_TRITS_LENGTH] = {0};
 
-    /* Get trits[:HASH_LENGTH] to an array */
-    memcpy(src, c->state->data, HASH_LENGTH);
+    /* Get trits[:HASH_TRITS_LENGTH] to an array */
+    memcpy(src, c->state->data, HASH_TRITS_LENGTH);
 
-    Trits_t *trits = initTrits(src, HASH_LENGTH);
+    Trits_t *trits = initTrits(src, HASH_TRITS_LENGTH);
     Trytes_t *trytes = trytes_from_trits(trits);
 
     Transform(c);
@@ -124,8 +124,8 @@ Curl *initCurl()
     if (!c)
         return NULL;
 
-    int8_t src[STATE_LENGTH] = {0};
-    c->state = initTrits(src, STATE_LENGTH);
+    int8_t src[STATE_TRITS_LENGTH] = {0};
+    c->state = initTrits(src, STATE_TRITS_LENGTH);
 
     return c;
 }

--- a/src/curl.h
+++ b/src/curl.h
@@ -1,10 +1,8 @@
 #ifndef CURL_H_
 #define CURL_H_
 
+#include "constants.h"
 #include "trinary.h"
-
-#define HASH_LENGTH 243
-#define STATE_LENGTH 3 * HASH_LENGTH
 
 typedef struct _curl {
     Trits_t *state;

--- a/src/pow_avx.h
+++ b/src/pow_avx.h
@@ -32,8 +32,8 @@ struct _pow_avx_context {
     /* Management of Multi-thread */
     int indexOfContext;
     /* Arguments of PoW */
-    int8_t input_trytes[TRANSACTION_LENGTH / 3]; /* 2673 */
-    int8_t output_trytes[TRANSACTION_LENGTH / 3]; /* 2673 */
+    int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
+    int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
 };
 
@@ -45,11 +45,8 @@ bool PowAVX(void *pow_ctx);
 #include <x86intrin.h>
 #endif
 
-#define HASH_LENGTH 243               // trits
-#define STATE_LENGTH 3 * HASH_LENGTH  // trits
-#define NONCE_LENGTH 81
 #define TX_LENGTH 2673  // trytes
-#define INCR_START HASH_LENGTH - NONCE_LENGTH + 4 + 27
+#define INCR_START HASH_TRITS_LENGTH - NONCE_TRITS_LENGTH + 4 + 27
 
 #ifdef __AVX2__
 #define HBITS 0xFFFFFFFFFFFFFFFFuLL

--- a/src/pow_c.h
+++ b/src/pow_c.h
@@ -33,8 +33,8 @@ struct _pow_c_context {
     /* Management of Multi-thread */
     int indexOfContext;
     /* Arguments of PoW */
-    int8_t input_trytes[TRANSACTION_LENGTH / 3]; /* 2673 */
-    int8_t output_trytes[TRANSACTION_LENGTH / 3]; /* 2673 */
+    int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
+    int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
 };
 
@@ -42,11 +42,8 @@ bool PowC(void *pow_ctx);
 
 #define HBITS 0xFFFFFFFFFFFFFFFFuLL
 #define LBITS 0x0000000000000000uLL
-#define HASH_LENGTH 243               // trits
-#define NONCE_LENGTH 81               // trits
-#define STATE_LENGTH 3 * HASH_LENGTH  // trits
 #define TX_LENGTH 2673                // trytes
-#define INCR_START HASH_LENGTH - NONCE_LENGTH + 4 + 27
+#define INCR_START HASH_TRITS_LENGTH - NONCE_TRITS_LENGTH + 4 + 27
 #define LOW0 \
     0xDB6DB6DB6DB6DB6DuLL  // 0b1101101101101101101101101101101101101101101101101101101101101101L;
 #define HIGH0 \

--- a/src/pow_cl.h
+++ b/src/pow_cl.h
@@ -13,8 +13,8 @@ struct _pow_cl_context {
     /* Management of Multi-thread */
     int indexOfContext;
     /* Arguments of PoW */
-    int8_t input_trytes[TRANSACTION_LENGTH / 3]; /* 2673 */
-    int8_t output_trytes[TRANSACTION_LENGTH / 3]; /* 2673 */
+    int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
+    int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
 };
 

--- a/src/pow_sse.h
+++ b/src/pow_sse.h
@@ -32,8 +32,8 @@ struct _pow_sse_context {
     /* Management of Multi-thread */
     int indexOfContext;
     /* Arguments of PoW */
-    int8_t input_trytes[TRANSACTION_LENGTH / 3]; /* 2673 */
-    int8_t output_trytes[TRANSACTION_LENGTH / 3]; /* 2673 */
+    int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
+    int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
 };
 
@@ -47,11 +47,8 @@ bool PowSSE(void *pow_ctx);
 
 #define HBITS 0xFFFFFFFFFFFFFFFFuLL
 #define LBITS 0x0000000000000000uLL
-#define HASH_LENGTH 243               // trits
-#define NONCE_LENGTH 81               // trits
-#define STATE_LENGTH 3 * HASH_LENGTH  // trits
 #define TX_LENGTH 2673                // trytes
-#define INCR_START HASH_LENGTH - NONCE_LENGTH + 4 + 27
+#define INCR_START HASH_TRITS_LENGTH - NONCE_TRITS_LENGTH + 4 + 27
 #define LOW00 \
     0xDB6DB6DB6DB6DB6DuLL  // 0b1101101101101101101101101101101101101101101101101101101101101101L;
 #define HIGH00 \

--- a/tests/test-pow.c
+++ b/tests/test-pow.c
@@ -123,7 +123,7 @@ int main()
         assert(ret_trits);
 
         /* Validation */
-        for (int i = HASH_LENGTH - 1; i >= HASH_LENGTH - mwm; i--) {
+        for (int i = HASH_TRITS_LENGTH - 1; i >= HASH_TRITS_LENGTH - mwm; i--) {
             assert(ret_trits->data[i] == 0);
         }
 


### PR DESCRIPTION
The original macros for trit length is renamed to *_TRITS_LENGTH
and add the corresponding *_TRYTES_LENGTH for tryte length.
Modified macros:
HASH_LENGTH
NONCE_LENGTH
STATE_LENGTH
TRANSACTION_LENGTH

Remove the duplicated "constants.h" inclusion
and re-defined macros as well.