### PR TITLE
Calculate and display hash count of PoW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ ifeq ("$(BUILD_JNI)","1")
 include mk/java.mk
 endif
 
+ifeq ("$(BUILD_STAT)","1")
+CFLAGS += -DENABLE_STAT
+endif
+
 TESTS = \
 	trinary \
 	curl \

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Reference Implementation (IRI). Additionally, dcurl also supports the FPGA-accel
                      downloading from [latest JAVA source](https://github.com/DLTcollab/iri).
     - ``BUILD_COMPAT``: build extra cCurl compatible interface.
     - ``BUILD_FPGA_ACCEL``: build the interface interacting with the Cyclone V FPGA based accelerator. Verified on DE10-nano board and Arrow SoCKit board.
+    - ``BUILD_STAT``: show the statistics of the PoW information.
 * Alternatively, you can specify conditional build as following:
 ```shell
 $ make BUILD_GPU=0 BUILD_JNI=1 BUILD_AVX=1
@@ -43,13 +44,15 @@ $ make BUILD_GPU=1 check
         [ Verified ]
 *** Validating build/test-curl ***
         [ Verified ]
-*** Validating build/test-multi_pow_cpu ***
+*** Validating build/test-durl ***
+[dcurl] Implementation GPU (OpenCL) is initialized successfully
         [ Verified ]
-*** Validating build/test-pow_sse ***
+*** Validating build/test-multi_pow ***
         [ Verified ]
-*** Validating build/test-pow_cl ***
-        [ Verified ]
-*** Validating build/test-multi_pow_gpu ***
+*** Validating build/test-pow ***
+GPU - OpenCL
+[dcurl] Implementation GPU (OpenCL) is initialized successfully
+Success.
         [ Verified ]
 ```
 
@@ -64,9 +67,41 @@ $ make BUILD_AVX=1 check
         [ Verified ]
 *** Validating build/test-curl ***
         [ Verified ]
+*** Validating build/test-dcurl ***
+[dcurl] Implementation CPU (Intel AVX) is initialized successfully
+        [ Verified ]
 *** Validating build/test-multi_pow_cpu ***
         [ Verified ]
-*** Validating build/test-pow_avx ***
+*** Validating build/test-pow ***
+CPU - AVX
+[dcurl] Implementation CPU (Intel AVX) is initialized successfully
+Success.
+        [ Verified ]
+```
+
+* Test with AVX and show the PoW statistics
+```shell
+$ make BUILD_AVX=1 BUILD_STAT=1 check
+```
+
+* Expected Results
+```
+*** Validating build/test-trinary ***
+        [ Verified ]
+*** Validating build/test-curl ***
+        [ Verified ]
+*** Validating build/test-dcurl ***
+[dcurl] Implementation CPU (Intel AVX) is initialized successfully
+        [ Verified ]
+*** Validating build/test-multi_pow_cpu ***
+        [ Verified ]
+*** Validating build/test-pow ***
+CPU - AVX
+[dcurl] Implementation CPU (Intel AVX) is initialized successfully
+Hash count: 7396100
+PoW execution time: 3 sec
+Hash rate: 2465366.667 kH/sec
+Success.
         [ Verified ]
 ```
 
@@ -83,11 +118,19 @@ root@lampa:~/dcurl# make BUILD_FPGA_ACCEL=1 check
         [ Verified ]
 *** Validating build/test-curl ***
         [ Verified ]
-*** Validating build/test-pow_c ***
+*** Validating build/test-dcurl ***
+[dcurl] Implementation CPU (Intel SSE) is initialized successfully
+[dcurl] Implementation FPGA is initialized successfully
         [ Verified ]
-*** Validating build/test-multi_pow_cpu ***
+*** Validating build/test-multi_pow ***
         [ Verified ]
-*** Validating build/test-pow_fpga_accel *** 
+*** Validating build/test-pow ***
+CPU - SSE
+[dcurl] Implementation CPU (Intel SSE) is initialized successfully
+Success.
+FPGA
+[dcurl] Implementation FPGA is initialized successfully
+Success.
         [ Verified ] 
 ```
 

--- a/mk/defs.mk
+++ b/mk/defs.mk
@@ -15,3 +15,6 @@ BUILD_COMPAT ?= 0
 
 # Build FPGA backend or not
 BUILD_FPGA_ACCEL ?= 0
+
+# Show the PoW-related statistic messages or not
+BUILD_STAT ?= 0

--- a/src/clcontext.h
+++ b/src/clcontext.h
@@ -41,6 +41,7 @@ typedef struct {
     cl_ulong max_memory;
     size_t num_work_group;
     KernelInfo kernel_info;
+    uint64_t hash_count;
 } CLContext;
 
 enum {

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,11 @@
+#ifndef COMMON_H_
+#define COMMON_H_
+
+typedef struct _pow_info PoW_Info;
+
+struct _pow_info {
+    double time;
+    uint64_t hash_count;
+};
+
+#endif

--- a/src/constants.h
+++ b/src/constants.h
@@ -4,7 +4,6 @@
 #define MinTryteValue -13
 #define MaxTryteValue 13
 #define SignatureSize 6561
-#define HashSize 243
 #define Depth 3
 #define Radix 3
 

--- a/src/implcontext.c
+++ b/src/implcontext.c
@@ -65,7 +65,7 @@ int8_t *getPoWResult(ImplContext *impl_ctx, void *pow_ctx)
     return impl_ctx->getPoWResult(pow_ctx);
 }
 
-uint64_t getHashCount(ImplContext *impl_ctx, void *pow_ctx)
+void *getPoWInfo(ImplContext *impl_ctx, void *pow_ctx)
 {
-    return impl_ctx->getHashCount(pow_ctx);
+    return impl_ctx->getPoWInfo(pow_ctx);
 }

--- a/src/implcontext.c
+++ b/src/implcontext.c
@@ -64,3 +64,8 @@ int8_t *getPoWResult(ImplContext *impl_ctx, void *pow_ctx)
 {
     return impl_ctx->getPoWResult(pow_ctx);
 }
+
+uint64_t getHashCount(ImplContext *impl_ctx, void *pow_ctx)
+{
+    return impl_ctx->getHashCount(pow_ctx);
+}

--- a/src/implcontext.h
+++ b/src/implcontext.h
@@ -25,6 +25,7 @@ struct _impl_context {
     void *(*getPoWContext)(ImplContext *impl_ctx, int8_t *trytes, int mwm);
     bool (*doThePoW)(void *pow_ctx);
     int8_t *(*getPoWResult)(void *pow_ctx);
+    uint64_t (*getHashCount)(void *pow_ctx);
     bool (*freePoWContext)(ImplContext *impl_ctx, void *pow_ctx);
 
     /* Linked list */
@@ -40,5 +41,6 @@ void *getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm);
 bool doThePoW(ImplContext *impl_ctx, void *pow_ctx);
 bool freePoWContext(ImplContext *impl_ctx, void *pow_ctx);
 int8_t *getPoWResult(ImplContext *impl_ctx, void *pow_ctx);
+uint64_t getHashCount(ImplContext *impl_ctx, void *pow_ctx);
 
 #endif

--- a/src/implcontext.h
+++ b/src/implcontext.h
@@ -25,7 +25,7 @@ struct _impl_context {
     void *(*getPoWContext)(ImplContext *impl_ctx, int8_t *trytes, int mwm);
     bool (*doThePoW)(void *pow_ctx);
     int8_t *(*getPoWResult)(void *pow_ctx);
-    uint64_t (*getHashCount)(void *pow_ctx);
+    void *(*getPoWInfo)(void *pow_ctx);
     bool (*freePoWContext)(ImplContext *impl_ctx, void *pow_ctx);
 
     /* Linked list */
@@ -41,6 +41,6 @@ void *getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm);
 bool doThePoW(ImplContext *impl_ctx, void *pow_ctx);
 bool freePoWContext(ImplContext *impl_ctx, void *pow_ctx);
 int8_t *getPoWResult(ImplContext *impl_ctx, void *pow_ctx);
-uint64_t getHashCount(ImplContext *impl_ctx, void *pow_ctx);
+void *getPoWInfo(ImplContext *impl_ctx, void *pow_ctx);
 
 #endif

--- a/src/pow_avx.c
+++ b/src/pow_avx.c
@@ -541,6 +541,7 @@ bool PowAVX(void *pow_ctx)
     /* Initialize the context */
     PoW_AVX_Context *ctx = (PoW_AVX_Context *) pow_ctx;
     ctx->stopPoW = 0;
+    ctx->hash_count = 0;
     pthread_mutex_init(&ctx->lock, NULL);
     pthread_t *threads = ctx->threads;
     Pwork_struct *pitem = ctx->pitem;
@@ -573,6 +574,7 @@ bool PowAVX(void *pow_ctx)
         pthread_join(threads[i], NULL);
         if (pitem[i].n == -1)
             completedIndex = i;
+        ctx->hash_count += (uint64_t) (pitem[i].ret >= 0 ? pitem[i].ret : -pitem[i].ret + 1);
     }
 
     nonce_trit = initTrits(nonce_array[completedIndex], NonceTrinarySize);
@@ -681,6 +683,11 @@ static int8_t *PoWAVX_getPoWResult(void *pow_ctx)
     return ret;
 }
 
+static uint64_t PoWAVX_getHashCount(void *pow_ctx)
+{
+    return ((PoW_AVX_Context *) pow_ctx)->hash_count;
+}
+
 ImplContext PoWAVX_Context = {
     .context = NULL,
     .description = "CPU (Intel AVX)",
@@ -693,4 +700,5 @@ ImplContext PoWAVX_Context = {
     .freePoWContext = PoWAVX_freePoWContext,
     .doThePoW = PowAVX,
     .getPoWResult = PoWAVX_getPoWResult,
+    .getHashCount = PoWAVX_getHashCount,
 };

--- a/src/pow_avx.c
+++ b/src/pow_avx.c
@@ -537,6 +537,7 @@ bool PowAVX(void *pow_ctx)
     bool res = true;
     Trits_t *nonce_trit = NULL;
     Trytes_t *tx_tryte = NULL, *nonce_tryte = NULL;
+    time_t start_time, end_time;
 
     /* Initialize the context */
     PoW_AVX_Context *ctx = (PoW_AVX_Context *) pow_ctx;
@@ -558,6 +559,7 @@ bool PowAVX(void *pow_ctx)
         goto fail;
     }
 
+    time(&start_time);
     /* Prepare arguments for pthread */
     for (int i = 0; i < ctx->num_threads; i++) {
         pitem[i].mid = c_state;
@@ -577,6 +579,8 @@ bool PowAVX(void *pow_ctx)
             completedIndex = i;
         ctx->pow_info->hash_count += (uint64_t) (pitem[i].ret >= 0 ? pitem[i].ret : -pitem[i].ret + 1);
     }
+    time(&end_time);
+    ctx->pow_info->time = difftime(end_time, start_time);
 
     nonce_trit = initTrits(nonce_array[completedIndex], NonceTrinarySize);
     if (!nonce_trit) {

--- a/src/pow_avx.c
+++ b/src/pow_avx.c
@@ -487,16 +487,16 @@ static int8_t *tx_to_cstate(Trytes_t *tx)
 {
     Trytes_t *inn = NULL;
     Trits_t *tr = NULL;
-    int8_t tyt[(transactionTrinarySize - HashSize) / 3] = {0};
+    int8_t tyt[TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH] = {0};
 
     Curl *c = initCurl();
     int8_t *c_state = (int8_t *) malloc(STATE_TRITS_LENGTH);
     if (!c || !c_state) goto fail;
 
-    /* Copy tx->data[:(transactionTrinarySize - HashSize) / 3] to tyt */
-    memcpy(tyt, tx->data, (transactionTrinarySize - HashSize) / 3);
+    /* Copy tx->data[:TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH] to tyt */
+    memcpy(tyt, tx->data, TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH);
 
-    inn = initTrytes(tyt, (transactionTrinarySize - HashSize) / 3);
+    inn = initTrytes(tyt, TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH);
     if (!inn) goto fail;
 
     Absorb(c, inn);
@@ -504,12 +504,12 @@ static int8_t *tx_to_cstate(Trytes_t *tx)
     tr = trits_from_trytes(tx);
     if (!tr) goto fail;
 
-    /* Prepare an array storing tr[transactionTrinarySize - HashSize:] */
-    memcpy(c_state, tr->data + transactionTrinarySize - HashSize,
-           tr->len - (transactionTrinarySize - HashSize));
-    memcpy(c_state + tr->len - (transactionTrinarySize - HashSize),
-           c->state->data + tr->len - (transactionTrinarySize - HashSize),
-           c->state->len - tr->len + (transactionTrinarySize - HashSize));
+    /* Prepare an array storing tr[TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH:] */
+    memcpy(c_state, tr->data + TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH,
+           tr->len - (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH));
+    memcpy(c_state + tr->len - (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH),
+           c->state->data + tr->len - (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH),
+           c->state->len - tr->len + (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH));
 
     freeTrobject(inn);
     freeTrobject(tr);
@@ -525,11 +525,11 @@ fail:
 
 static void nonce_to_result(Trytes_t *tx, Trytes_t *nonce, int8_t *ret)
 {
-    int rst_len = tx->len - NonceTrinarySize / 3 + nonce->len;
+    int rst_len = tx->len - NONCE_TRYTES_LENGTH + nonce->len;
 
-    memcpy(ret, tx->data, tx->len - NonceTrinarySize / 3);
-    memcpy(ret + tx->len - NonceTrinarySize / 3, nonce->data,
-           rst_len - (tx->len - NonceTrinarySize / 3));
+    memcpy(ret, tx->data, tx->len - NONCE_TRYTES_LENGTH);
+    memcpy(ret + tx->len - NONCE_TRYTES_LENGTH, nonce->data,
+           rst_len - (tx->len - NONCE_TRYTES_LENGTH));
 }
 
 bool PowAVX(void *pow_ctx)
@@ -582,7 +582,7 @@ bool PowAVX(void *pow_ctx)
     time(&end_time);
     ctx->pow_info->time = difftime(end_time, start_time);
 
-    nonce_trit = initTrits(nonce_array[completedIndex], NonceTrinarySize);
+    nonce_trit = initTrits(nonce_array[completedIndex], NONCE_TRITS_LENGTH);
     if (!nonce_trit) {
         res = false;
         goto fail;
@@ -618,7 +618,7 @@ static bool PoWAVX_Context_Initialize(ImplContext *impl_ctx)
     void *threads_chunk = malloc(impl_ctx->num_max_thread * sizeof(pthread_t) * nproc);
     void *pitem_chunk = malloc(impl_ctx->num_max_thread * sizeof(Pwork_struct) * nproc);
     void *nonce_ptr_chunk = malloc(impl_ctx->num_max_thread * sizeof(int8_t *) * nproc);
-    void *nonce_chunk = malloc(impl_ctx->num_max_thread * NonceTrinarySize * nproc);
+    void *nonce_chunk = malloc(impl_ctx->num_max_thread * NONCE_TRITS_LENGTH * nproc);
     void *pow_info_chunk = malloc(impl_ctx->num_max_thread * sizeof(PoW_Info));
     if (!threads_chunk || !pitem_chunk || !nonce_ptr_chunk || !nonce_chunk || !pow_info_chunk) goto fail;
 
@@ -627,8 +627,8 @@ static bool PoWAVX_Context_Initialize(ImplContext *impl_ctx)
         ctx[i].pitem = (Pwork_struct *) (pitem_chunk + i * sizeof(Pwork_struct) * nproc);
         ctx[i].nonce_array = (int8_t **) (nonce_ptr_chunk + i * sizeof(int8_t *) * nproc);
         for (int j = 0; j < nproc; j++)
-            ctx[i].nonce_array[j] = (int8_t *) (nonce_chunk + i * NonceTrinarySize * nproc +
-                                                j * NonceTrinarySize);
+            ctx[i].nonce_array[j] = (int8_t *) (nonce_chunk + i * NONCE_TRITS_LENGTH * nproc +
+                                                j * NONCE_TRITS_LENGTH);
         ctx[i].pow_info = (PoW_Info *) (pow_info_chunk + i * sizeof(PoW_Info));
         ctx[i].num_threads = nproc;
         impl_ctx->bitmap = impl_ctx->bitmap << 1 | 0x1;

--- a/src/pow_avx.h
+++ b/src/pow_avx.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <pthread.h>
+#include "common.h"
 #include "constants.h"
 
 typedef struct _pwork_struct Pwork_struct;
@@ -35,8 +36,8 @@ struct _pow_avx_context {
     int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
-    /* PoW-related result */
-    uint64_t hash_count;
+    /* PoW-related information */
+    PoW_Info *pow_info;
 };
 
 bool PowAVX(void *pow_ctx);

--- a/src/pow_avx.h
+++ b/src/pow_avx.h
@@ -35,6 +35,8 @@ struct _pow_avx_context {
     int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
+    /* PoW-related result */
+    uint64_t hash_count;
 };
 
 bool PowAVX(void *pow_ctx);

--- a/src/pow_c.c
+++ b/src/pow_c.c
@@ -302,7 +302,8 @@ bool PowC(void *pow_ctx)
     /* Initialize the context */
     PoW_C_Context *ctx = (PoW_C_Context *) pow_ctx;
     ctx->stopPoW = 0;
-    ctx->hash_count = 0;
+    ctx->pow_info->time = 0;
+    ctx->pow_info->hash_count = 0;
     pthread_mutex_init(&ctx->lock, NULL);
     pthread_t *threads = ctx->threads;
     Pwork_struct *pitem = ctx->pitem;
@@ -335,7 +336,7 @@ bool PowC(void *pow_ctx)
         pthread_join(threads[i], NULL);
         if (pitem[i].n == -1)
             completedIndex = i;
-        ctx->hash_count += (uint64_t) (pitem[i].ret >= 0 ? pitem[i].ret : -pitem[i].ret + 1);
+        ctx->pow_info->hash_count += (uint64_t) (pitem[i].ret >= 0 ? pitem[i].ret : -pitem[i].ret + 1);
     }
 
     nonce_trit = initTrits(nonce_array[completedIndex], NonceTrinarySize);
@@ -374,7 +375,8 @@ static bool PoWC_Context_Initialize(ImplContext *impl_ctx)
     void *pitem_chunk = malloc(impl_ctx->num_max_thread * sizeof(Pwork_struct) * nproc);
     void *nonce_ptr_chunk = malloc(impl_ctx->num_max_thread * sizeof(int8_t *) * nproc);
     void *nonce_chunk = malloc(impl_ctx->num_max_thread * NonceTrinarySize * nproc);
-    if (!threads_chunk || !pitem_chunk || !nonce_ptr_chunk || !nonce_chunk) goto fail;
+    void *pow_info_chunk = malloc(impl_ctx->num_max_thread * sizeof(PoW_Info));
+    if (!threads_chunk || !pitem_chunk || !nonce_ptr_chunk || !nonce_chunk || !pow_info_chunk) goto fail;
 
     for (int i = 0; i < impl_ctx->num_max_thread; i++) {
         ctx[i].threads = (pthread_t *) (threads_chunk + i * sizeof(pthread_t) * nproc);
@@ -383,6 +385,7 @@ static bool PoWC_Context_Initialize(ImplContext *impl_ctx)
         for (int j = 0; j < nproc; j++)
             ctx[i].nonce_array[j] = (int8_t *) (nonce_chunk + i * NonceTrinarySize * nproc +
                                                 j * NonceTrinarySize);
+        ctx[i].pow_info = (PoW_Info *) (pow_info_chunk + i * sizeof(PoW_Info));
         ctx[i].num_threads = nproc;
         impl_ctx->bitmap = impl_ctx->bitmap << 1 | 0x1;
     }
@@ -396,6 +399,7 @@ fail:
     free(pitem_chunk);
     free(nonce_ptr_chunk);
     free(nonce_chunk);
+    free(pow_info_chunk);
     return false;
 }
 
@@ -406,6 +410,7 @@ static void PoWC_Context_Destroy(ImplContext *impl_ctx)
     free(ctx[0].pitem);
     free(ctx[0].nonce_array[0]);
     free(ctx[0].nonce_array);
+    free(ctx[0].pow_info);
     free(ctx);
 }
 
@@ -443,9 +448,9 @@ static int8_t *PoWC_getPoWResult(void *pow_ctx)
     return ret;
 }
 
-static uint64_t PoWC_getHashCount(void *pow_ctx)
+static void *PoWC_getPoWInfo(void *pow_ctx)
 {
-    return ((PoW_C_Context *) pow_ctx)->hash_count;
+    return ((PoW_C_Context *) pow_ctx)->pow_info;
 }
 
 ImplContext PoWC_Context = {
@@ -460,5 +465,5 @@ ImplContext PoWC_Context = {
     .freePoWContext = PoWC_freePoWContext,
     .doThePoW = PowC,
     .getPoWResult = PoWC_getPoWResult,
-    .getHashCount = PoWC_getHashCount,
+    .getPoWInfo = PoWC_getPoWInfo,
 };

--- a/src/pow_c.c
+++ b/src/pow_c.c
@@ -302,6 +302,7 @@ bool PowC(void *pow_ctx)
     /* Initialize the context */
     PoW_C_Context *ctx = (PoW_C_Context *) pow_ctx;
     ctx->stopPoW = 0;
+    ctx->hash_count = 0;
     pthread_mutex_init(&ctx->lock, NULL);
     pthread_t *threads = ctx->threads;
     Pwork_struct *pitem = ctx->pitem;
@@ -334,6 +335,7 @@ bool PowC(void *pow_ctx)
         pthread_join(threads[i], NULL);
         if (pitem[i].n == -1)
             completedIndex = i;
+        ctx->hash_count += (uint64_t) (pitem[i].ret >= 0 ? pitem[i].ret : -pitem[i].ret + 1);
     }
 
     nonce_trit = initTrits(nonce_array[completedIndex], NonceTrinarySize);
@@ -441,6 +443,11 @@ static int8_t *PoWC_getPoWResult(void *pow_ctx)
     return ret;
 }
 
+static uint64_t PoWC_getHashCount(void *pow_ctx)
+{
+    return ((PoW_C_Context *) pow_ctx)->hash_count;
+}
+
 ImplContext PoWC_Context = {
     .context = NULL,
     .description = "CPU (Pure C)",
@@ -453,4 +460,5 @@ ImplContext PoWC_Context = {
     .freePoWContext = PoWC_freePoWContext,
     .doThePoW = PowC,
     .getPoWResult = PoWC_getPoWResult,
+    .getHashCount = PoWC_getHashCount,
 };

--- a/src/pow_c.c
+++ b/src/pow_c.c
@@ -248,16 +248,16 @@ static int8_t *tx_to_cstate(Trytes_t *tx)
 {
     Trytes_t *inn = NULL;
     Trits_t *tr = NULL;
-    int8_t tyt[(transactionTrinarySize - HashSize) / 3] = {0};
+    int8_t tyt[TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH] = {0};
 
     Curl *c = initCurl();
     int8_t *c_state = (int8_t *) malloc(STATE_TRITS_LENGTH);
     if (!c || !c_state) goto fail;
 
-    /* Copy tx->data[:(transactionTrinarySize - HashSize) / 3] to tyt */
-    memcpy(tyt, tx->data, (transactionTrinarySize - HashSize) / 3);
+    /* Copy tx->data[:TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH] to tyt */
+    memcpy(tyt, tx->data, TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH);
 
-    inn = initTrytes(tyt, (transactionTrinarySize - HashSize) / 3);
+    inn = initTrytes(tyt, TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH);
     if (!inn) goto fail;
 
     Absorb(c, inn);
@@ -265,12 +265,12 @@ static int8_t *tx_to_cstate(Trytes_t *tx)
     tr = trits_from_trytes(tx);
     if (!tr) goto fail;
 
-    /* Prepare an array storing tr[transactionTrinarySize - HashSize:] */
-    memcpy(c_state, tr->data + transactionTrinarySize - HashSize,
-           tr->len - (transactionTrinarySize - HashSize));
-    memcpy(c_state + tr->len - (transactionTrinarySize - HashSize),
-           c->state->data + tr->len - (transactionTrinarySize - HashSize),
-           c->state->len - tr->len + (transactionTrinarySize - HashSize));
+    /* Prepare an array storing tr[TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH:] */
+    memcpy(c_state, tr->data + TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH,
+           tr->len - (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH));
+    memcpy(c_state + tr->len - (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH),
+           c->state->data + tr->len - (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH),
+           c->state->len - tr->len + (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH));
 
     freeTrobject(inn);
     freeTrobject(tr);
@@ -286,11 +286,11 @@ fail:
 
 static void nonce_to_result(Trytes_t *tx, Trytes_t *nonce, int8_t *ret)
 {
-    int rst_len = tx->len - NonceTrinarySize / 3 + nonce->len;
+    int rst_len = tx->len - NONCE_TRYTES_LENGTH + nonce->len;
 
-    memcpy(ret, tx->data, tx->len - NonceTrinarySize / 3);
-    memcpy(ret + tx->len - NonceTrinarySize / 3, nonce->data,
-           rst_len - (tx->len - NonceTrinarySize / 3));
+    memcpy(ret, tx->data, tx->len - NONCE_TRYTES_LENGTH);
+    memcpy(ret + tx->len - NONCE_TRYTES_LENGTH, nonce->data,
+           rst_len - (tx->len - NONCE_TRYTES_LENGTH));
 }
 
 bool PowC(void *pow_ctx)
@@ -343,7 +343,7 @@ bool PowC(void *pow_ctx)
     time(&end_time);
     ctx->pow_info->time = difftime(end_time, start_time);
 
-    nonce_trit = initTrits(nonce_array[completedIndex], NonceTrinarySize);
+    nonce_trit = initTrits(nonce_array[completedIndex], NONCE_TRITS_LENGTH);
     if (!nonce_trit) {
         res = false;
         goto fail;
@@ -378,7 +378,7 @@ static bool PoWC_Context_Initialize(ImplContext *impl_ctx)
     void *threads_chunk = malloc(impl_ctx->num_max_thread * sizeof(pthread_t) * nproc);
     void *pitem_chunk = malloc(impl_ctx->num_max_thread * sizeof(Pwork_struct) * nproc);
     void *nonce_ptr_chunk = malloc(impl_ctx->num_max_thread * sizeof(int8_t *) * nproc);
-    void *nonce_chunk = malloc(impl_ctx->num_max_thread * NonceTrinarySize * nproc);
+    void *nonce_chunk = malloc(impl_ctx->num_max_thread * NONCE_TRITS_LENGTH * nproc);
     void *pow_info_chunk = malloc(impl_ctx->num_max_thread * sizeof(PoW_Info));
     if (!threads_chunk || !pitem_chunk || !nonce_ptr_chunk || !nonce_chunk || !pow_info_chunk) goto fail;
 
@@ -387,8 +387,8 @@ static bool PoWC_Context_Initialize(ImplContext *impl_ctx)
         ctx[i].pitem = (Pwork_struct *) (pitem_chunk + i * sizeof(Pwork_struct) * nproc);
         ctx[i].nonce_array = (int8_t **) (nonce_ptr_chunk + i * sizeof(int8_t *) * nproc);
         for (int j = 0; j < nproc; j++)
-            ctx[i].nonce_array[j] = (int8_t *) (nonce_chunk + i * NonceTrinarySize * nproc +
-                                                j * NonceTrinarySize);
+            ctx[i].nonce_array[j] = (int8_t *) (nonce_chunk + i * NONCE_TRITS_LENGTH * nproc +
+                                                j * NONCE_TRITS_LENGTH);
         ctx[i].pow_info = (PoW_Info *) (pow_info_chunk + i * sizeof(PoW_Info));
         ctx[i].num_threads = nproc;
         impl_ctx->bitmap = impl_ctx->bitmap << 1 | 0x1;

--- a/src/pow_c.c
+++ b/src/pow_c.c
@@ -298,6 +298,7 @@ bool PowC(void *pow_ctx)
     bool res = true;
     Trits_t *nonce_trit = NULL;
     Trytes_t *tx_tryte = NULL, *nonce_tryte = NULL;
+    time_t start_time, end_time;
 
     /* Initialize the context */
     PoW_C_Context *ctx = (PoW_C_Context *) pow_ctx;
@@ -319,6 +320,7 @@ bool PowC(void *pow_ctx)
         goto fail;
     }
 
+    time(&start_time);
     /* Prepare arguments for pthread */
     for (int i = 0; i < ctx->num_threads; i++) {
         pitem[i].mid = c_state;
@@ -338,6 +340,8 @@ bool PowC(void *pow_ctx)
             completedIndex = i;
         ctx->pow_info->hash_count += (uint64_t) (pitem[i].ret >= 0 ? pitem[i].ret : -pitem[i].ret + 1);
     }
+    time(&end_time);
+    ctx->pow_info->time = difftime(end_time, start_time);
 
     nonce_trit = initTrits(nonce_array[completedIndex], NonceTrinarySize);
     if (!nonce_trit) {

--- a/src/pow_c.h
+++ b/src/pow_c.h
@@ -36,6 +36,8 @@ struct _pow_c_context {
     int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
+    /* PoW-related result */
+    uint64_t hash_count;
 };
 
 bool PowC(void *pow_ctx);

--- a/src/pow_c.h
+++ b/src/pow_c.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <pthread.h>
+#include "common.h"
 #include "constants.h"
 
 typedef struct _pwork_struct Pwork_struct;
@@ -36,8 +37,8 @@ struct _pow_c_context {
     int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
-    /* PoW-related result */
-    uint64_t hash_count;
+    /* PoW-related information */
+    PoW_Info *pow_info;
 };
 
 bool PowC(void *pow_ctx);

--- a/src/pow_cl.c
+++ b/src/pow_cl.c
@@ -197,6 +197,7 @@ bool PowCL(void *pow_ctx)
     int8_t *c_state = NULL, *pow_result = NULL;
     Trits_t *tx_trit = NULL;
     Trytes_t *tx_tryte = NULL, *res_tryte = NULL;
+    time_t start_time, end_time;
 
     PoW_CL_Context *ctx = (PoW_CL_Context *) pow_ctx;
 
@@ -215,7 +216,10 @@ bool PowCL(void *pow_ctx)
         goto fail;
     }
 
+    time(&start_time);
     pow_result = pwork(c_state, ctx->mwm, ctx->clctx);
+    time(&end_time);
+    ctx->pow_info->time = difftime(end_time, start_time);
     if (!pow_result) {
         res = false;
         goto fail;

--- a/src/pow_cl.c
+++ b/src/pow_cl.c
@@ -155,16 +155,16 @@ static int8_t *tx_to_cstate(Trytes_t *tx)
 {
     Trytes_t *inn = NULL;
     Trits_t *tr = NULL;
-    int8_t tyt[(transactionTrinarySize - HashSize) / 3] = {0};
+    int8_t tyt[TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH] = {0};
 
     Curl *c = initCurl();
     int8_t *c_state = (int8_t *) malloc(STATE_TRITS_LENGTH);
     if (!c || !c_state) goto fail;
 
-    /* Copy tx->data[:(transactionTrinarySize - HashSize) / 3] to tyt */
-    memcpy(tyt, tx->data, (transactionTrinarySize - HashSize) / 3);
+    /* Copy tx->data[:TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH] to tyt */
+    memcpy(tyt, tx->data, TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH);
 
-    inn = initTrytes(tyt, (transactionTrinarySize - HashSize) / 3);
+    inn = initTrytes(tyt, TRANSACTION_TRYTES_LENGTH - HASH_TRYTES_LENGTH);
     if (!inn) goto fail;
 
     Absorb(c, inn);
@@ -172,12 +172,12 @@ static int8_t *tx_to_cstate(Trytes_t *tx)
     tr = trits_from_trytes(tx);
     if (!tr) goto fail;
 
-    /* Prepare an array storing tr[transactionTrinarySize - HashSize:] */
-    memcpy(c_state, tr->data + transactionTrinarySize - HashSize,
-           tr->len - (transactionTrinarySize - HashSize));
-    memcpy(c_state + tr->len - (transactionTrinarySize - HashSize),
-           c->state->data + tr->len - (transactionTrinarySize - HashSize),
-           c->state->len - tr->len + (transactionTrinarySize - HashSize));
+    /* Prepare an array storing tr[TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH:] */
+    memcpy(c_state, tr->data + TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH,
+           tr->len - (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH));
+    memcpy(c_state + tr->len - (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH),
+           c->state->data + tr->len - (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH),
+           c->state->len - tr->len + (TRANSACTION_TRITS_LENGTH - HASH_TRITS_LENGTH));
 
     freeTrobject(inn);
     freeTrobject(tr);

--- a/src/pow_cl.h
+++ b/src/pow_cl.h
@@ -16,6 +16,8 @@ struct _pow_cl_context {
     int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
+    /* PoW-related result */
+    uint64_t hash_count;
 };
 
 bool PowCL(void *pow_ctx);
@@ -33,5 +35,7 @@ bool PowCL(void *pow_ctx);
 #define HIGH_2 0xFFC01FFFF803FFFF
 #define LOW_3 0xFFC0000007FFFFFF
 #define HIGH_3 0x003FFFFFFFFFFFFF
+
+#define LOOP_COUNT 32
 
 #endif

--- a/src/pow_cl.h
+++ b/src/pow_cl.h
@@ -3,6 +3,7 @@
 
 #include "trinary.h"
 #include "clcontext.h"
+#include "common.h"
 #include "constants.h"
 #include <stdbool.h>
 
@@ -16,8 +17,8 @@ struct _pow_cl_context {
     int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
-    /* PoW-related result */
-    uint64_t hash_count;
+    /* PoW-related information */
+    PoW_Info *pow_info;
 };
 
 bool PowCL(void *pow_ctx);

--- a/src/pow_fpga_accel.c
+++ b/src/pow_fpga_accel.c
@@ -27,6 +27,7 @@
 static bool PoWFPGAAccel(void *pow_ctx)
 {
     PoW_FPGA_Accel_Context *ctx = (PoW_FPGA_Accel_Context *) pow_ctx;
+    ctx->hash_count = 0;
 
     int8_t fpga_out_nonce_trit[NonceTrinarySize];
 
@@ -173,6 +174,11 @@ static int8_t *PoWFPGAAccel_getPoWResult(void *pow_ctx)
     return ret;
 }
 
+static uint64_t PoWFPGAAccel_getHashCount(void *pow_ctx)
+{
+    return ((PoW_FPGA_Accel_Context *) pow_ctx)->hash_count;
+}
+
 ImplContext PoWFPGAAccel_Context = {
     .context = NULL,
     .description = "FPGA",
@@ -185,4 +191,5 @@ ImplContext PoWFPGAAccel_Context = {
     .freePoWContext = PoWFPGAAccel_freePoWContext,
     .doThePoW = PoWFPGAAccel,
     .getPoWResult = PoWFPGAAccel_getPoWResult,
+    .getHashCount = PoWFPGAAccel_getHashCount,
 };

--- a/src/pow_fpga_accel.c
+++ b/src/pow_fpga_accel.c
@@ -38,6 +38,7 @@ static bool PoWFPGAAccel(void *pow_ctx)
 
     Trytes_t *object_tryte = NULL, nonce_tryte = NULL;
     Trits_t *object_trit = NULL, *object_nonce_trit = NULL;
+    time_t start_time, end_time;
 
     object_tryte =
         initTrytes(ctx->input_trytes, (transactionTrinarySize) / 3);

--- a/src/pow_fpga_accel.c
+++ b/src/pow_fpga_accel.c
@@ -30,7 +30,7 @@ static bool PoWFPGAAccel(void *pow_ctx)
     ctx->pow_info->time = 0;
     ctx->pow_info->hash_count = 0;
 
-    int8_t fpga_out_nonce_trit[NonceTrinarySize];
+    int8_t fpga_out_nonce_trit[NONCE_TRITS_LENGTH];
 
     char result[4];
     char buf[4];
@@ -41,7 +41,7 @@ static bool PoWFPGAAccel(void *pow_ctx)
     time_t start_time, end_time;
 
     object_tryte =
-        initTrytes(ctx->input_trytes, (transactionTrinarySize) / 3);
+        initTrytes(ctx->input_trytes, TRANSACTION_TRYTES_LENGTH);
     if (!object_tryte) return false;
 
     object_trit = trits_from_trytes(object_tryte);
@@ -54,7 +54,7 @@ static bool PoWFPGAAccel(void *pow_ctx)
     lseek(ctx->ctrl_fd, 0, 0);
     lseek(ctx->out_fd, 0, 0);
 
-    if (write(ctx->in_fd, (char *) object_trits->data, transactionTrinarySize) <
+    if (write(ctx->in_fd, (char *) object_trits->data, TRANSACTION_TRITS_LENGTH) <
         0) {
         res = false;
         goto fail;
@@ -70,13 +70,13 @@ static bool PoWFPGAAccel(void *pow_ctx)
         goto fail;
     }
 
-    if (read(ctx->out_fd, (char *) fpga_out_nonce_trit, NonceTrinarySize) < 0) {
+    if (read(ctx->out_fd, (char *) fpga_out_nonce_trit, NONCE_TRITS_LENGTH) < 0) {
         res = false;
         goto fail;
     }
 
     object_nonce_trit =
-        initTrits(fpga_out_nonce_trit, NonceTrinarySize);
+        initTrits(fpga_out_nonce_trit, NONCE_TRITS_LENGTH);
     if (!object_nonce_trit) {
         res = false;
         goto fail;
@@ -90,7 +90,7 @@ static bool PoWFPGAAccel(void *pow_ctx)
 
     memcpy(ctx->output_trytes, ctx->input_trytes, (NonceTrinaryOffset) / 3);
     memcpy(ctx->output_trytes + ((NonceTrinaryOffset) / 3), nonce_trytes->data,
-           ((transactionTrinarySize) - (NonceTrinaryOffset)) / 3);
+           ((TRANSACTION_TRITS_LENGTH) - (NonceTrinaryOffset)) / 3);
 
 fail:
     freeTrobject(object_tryte);
@@ -153,7 +153,7 @@ static void *PoWFPGAAccel_getPoWContext(ImplContext *impl_ctx,
                                         int mwm)
 {
     PoW_FPGA_Accel_Context *ctx = impl_ctx->context;
-    memcpy(ctx->input_trytes, trytes, (transactionTrinarySize) / 3);
+    memcpy(ctx->input_trytes, trytes, TRANSACTION_TRYTES_LENGTH);
     ctx->mwm = mwm;
     ctx->indexOfContext = 0;
 
@@ -168,11 +168,11 @@ static bool PoWFPGAAccel_freePoWContext(ImplContext *impl_ctx, void *pow_ctx)
 static int8_t *PoWFPGAAccel_getPoWResult(void *pow_ctx)
 {
     int8_t *ret =
-        (int8_t *) malloc(sizeof(int8_t) * ((transactionTrinarySize) / 3));
+        (int8_t *) malloc(sizeof(int8_t) * TRANSACTION_TRYTES_LENGTH);
     if (!ret)
         return NULL;
     memcpy(ret, ((PoW_FPGA_Accel_Context *) pow_ctx)->output_trytes,
-           (transactionTrinarySize) / 3);
+           TRANSACTION_TRYTES_LENGTH);
     return ret;
 }
 

--- a/src/pow_fpga_accel.c
+++ b/src/pow_fpga_accel.c
@@ -27,7 +27,8 @@
 static bool PoWFPGAAccel(void *pow_ctx)
 {
     PoW_FPGA_Accel_Context *ctx = (PoW_FPGA_Accel_Context *) pow_ctx;
-    ctx->hash_count = 0;
+    ctx->pow_info->time = 0;
+    ctx->pow_info->hash_count = 0;
 
     int8_t fpga_out_nonce_trit[NonceTrinarySize];
 
@@ -174,9 +175,9 @@ static int8_t *PoWFPGAAccel_getPoWResult(void *pow_ctx)
     return ret;
 }
 
-static uint64_t PoWFPGAAccel_getHashCount(void *pow_ctx)
+static void *PoWFPGAAccel_getPoWInfo(void *pow_ctx)
 {
-    return ((PoW_FPGA_Accel_Context *) pow_ctx)->hash_count;
+    return ((PoW_FPGA_Accel_Context *) pow_ctx)->pow_info;
 }
 
 ImplContext PoWFPGAAccel_Context = {
@@ -191,5 +192,5 @@ ImplContext PoWFPGAAccel_Context = {
     .freePoWContext = PoWFPGAAccel_freePoWContext,
     .doThePoW = PoWFPGAAccel,
     .getPoWResult = PoWFPGAAccel_getPoWResult,
-    .getHashCount = PoWFPGAAccel_getHashCount,
+    .getPoWInfo = PoWFPGAAccel_getPoWInfo,
 };

--- a/src/pow_fpga_accel.h
+++ b/src/pow_fpga_accel.h
@@ -13,6 +13,8 @@ struct _pow_fpga_accel_context {
     int8_t input_trytes[(transactionTrinarySize) / 3];  /* 2673 */
     int8_t output_trytes[(transactionTrinarySize) / 3]; /* 2673 */
     int mwm;
+    /* PoW-related result */
+    uint64_t hash_count;
     /* Device files for the PFGA accelerator*/
     int ctrl_fd;
     int in_fd;

--- a/src/pow_fpga_accel.h
+++ b/src/pow_fpga_accel.h
@@ -2,6 +2,7 @@
 #define POW_FPGA_ACCEL_H_
 
 #include <stdint.h>
+#include "common.h"
 #include "constants.h"
 
 typedef struct _pow_fpga_accel_context PoW_FPGA_Accel_Context;
@@ -13,8 +14,8 @@ struct _pow_fpga_accel_context {
     int8_t input_trytes[(transactionTrinarySize) / 3];  /* 2673 */
     int8_t output_trytes[(transactionTrinarySize) / 3]; /* 2673 */
     int mwm;
-    /* PoW-related result */
-    uint64_t hash_count;
+    /* PoW-related information */
+    PoW_Info *pow_info;
     /* Device files for the PFGA accelerator*/
     int ctrl_fd;
     int in_fd;

--- a/src/pow_fpga_accel.h
+++ b/src/pow_fpga_accel.h
@@ -11,8 +11,8 @@ struct _pow_fpga_accel_context {
     /* Management of Multi-thread */
     int indexOfContext;
     /* Arguments of PoW */
-    int8_t input_trytes[(transactionTrinarySize) / 3];  /* 2673 */
-    int8_t output_trytes[(transactionTrinarySize) / 3]; /* 2673 */
+    int8_t input_trytes[TRANSACTION_TRYTES_LENGTH];  /* 2673 */
+    int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
     /* PoW-related information */
     PoW_Info *pow_info;

--- a/src/pow_sse.c
+++ b/src/pow_sse.c
@@ -315,6 +315,7 @@ bool PowSSE(void *pow_ctx)
     bool res = true;
     Trits_t *nonce_trit = NULL;
     Trytes_t *tx_tryte = NULL, *nonce_tryte = NULL;
+    time_t start_time, end_time;
 
     /* Initialize the context */
     PoW_SSE_Context *ctx = (PoW_SSE_Context *) pow_ctx;
@@ -336,6 +337,7 @@ bool PowSSE(void *pow_ctx)
         goto fail;
     }
 
+    time(&start_time);
     /* Prepare arguments for pthread */
     for (int i = 0; i < ctx->num_threads; i++) {
         pitem[i].mid = c_state;
@@ -355,6 +357,8 @@ bool PowSSE(void *pow_ctx)
             completedIndex = i;
         ctx->pow_info->hash_count += (uint64_t) (pitem[i].ret >= 0 ? pitem[i].ret : -pitem[i].ret + 1);
     }
+    time(&end_time);
+    ctx->pow_info->time = difftime(end_time, start_time);
 
     nonce_trit = initTrits(nonce_array[completedIndex], NonceTrinarySize);
     if (!nonce_trit) {

--- a/src/pow_sse.c
+++ b/src/pow_sse.c
@@ -319,7 +319,8 @@ bool PowSSE(void *pow_ctx)
     /* Initialize the context */
     PoW_SSE_Context *ctx = (PoW_SSE_Context *) pow_ctx;
     ctx->stopPoW = 0;
-    ctx->hash_count = 0;
+    ctx->pow_info->time = 0;
+    ctx->pow_info->hash_count = 0;
     pthread_mutex_init(&ctx->lock, NULL);
     pthread_t *threads = ctx->threads;
     Pwork_struct *pitem = ctx->pitem;
@@ -352,7 +353,7 @@ bool PowSSE(void *pow_ctx)
         pthread_join(threads[i], NULL);
         if (pitem[i].n == -1)
             completedIndex = i;
-        ctx->hash_count += (uint64_t) (pitem[i].ret >= 0 ? pitem[i].ret : -pitem[i].ret + 1);
+        ctx->pow_info->hash_count += (uint64_t) (pitem[i].ret >= 0 ? pitem[i].ret : -pitem[i].ret + 1);
     }
 
     nonce_trit = initTrits(nonce_array[completedIndex], NonceTrinarySize);
@@ -391,7 +392,8 @@ static bool PoWSSE_Context_Initialize(ImplContext *impl_ctx)
     void *pitem_chunk = malloc(impl_ctx->num_max_thread * sizeof(Pwork_struct) * nproc);
     void *nonce_ptr_chunk = malloc(impl_ctx->num_max_thread * sizeof(int8_t *) * nproc);
     void *nonce_chunk = malloc(impl_ctx->num_max_thread * NonceTrinarySize * nproc);
-    if (!threads_chunk || !pitem_chunk || !nonce_ptr_chunk || !nonce_chunk) goto fail;
+    void *pow_info_chunk = malloc(impl_ctx->num_max_thread * sizeof(PoW_Info));
+    if (!threads_chunk || !pitem_chunk || !nonce_ptr_chunk || !nonce_chunk || !pow_info_chunk) goto fail;
 
     for (int i = 0; i < impl_ctx->num_max_thread; i++) {
         ctx[i].threads = (pthread_t *) (threads_chunk + i * sizeof(pthread_t) * nproc);
@@ -400,6 +402,7 @@ static bool PoWSSE_Context_Initialize(ImplContext *impl_ctx)
         for (int j = 0; j < nproc; j++)
             ctx[i].nonce_array[j] = (int8_t *) (nonce_chunk + i * NonceTrinarySize * nproc +
                                                 j * NonceTrinarySize);
+        ctx[i].pow_info = (PoW_Info *) (pow_info_chunk + i * sizeof(PoW_Info));
         ctx[i].num_threads = nproc;
         impl_ctx->bitmap = impl_ctx->bitmap << 1 | 0x1;
     }
@@ -413,6 +416,7 @@ fail:
     free(pitem_chunk);
     free(nonce_ptr_chunk);
     free(nonce_chunk);
+    free(pow_info_chunk);
     return false;
 }
 
@@ -423,6 +427,7 @@ static void PoWSSE_Context_Destroy(ImplContext *impl_ctx)
     free(ctx[0].pitem);
     free(ctx[0].nonce_array[0]);
     free(ctx[0].nonce_array);
+    free(ctx[0].pow_info);
     free(ctx);
 }
 
@@ -460,9 +465,9 @@ static int8_t *PoWSSE_getPoWResult(void *pow_ctx)
     return ret;
 }
 
-static uint64_t PoWSSE_getHashCount(void *pow_ctx)
+static void *PoWSSE_getPoWInfo(void *pow_ctx)
 {
-    return ((PoW_SSE_Context *) pow_ctx)->hash_count;
+    return ((PoW_SSE_Context *) pow_ctx)->pow_info;
 }
 
 ImplContext PoWSSE_Context = {
@@ -477,5 +482,5 @@ ImplContext PoWSSE_Context = {
     .freePoWContext = PoWSSE_freePoWContext,
     .doThePoW = PowSSE,
     .getPoWResult = PoWSSE_getPoWResult,
-    .getHashCount = PoWSSE_getHashCount,
+    .getPoWInfo = PoWSSE_getPoWInfo,
 };

--- a/src/pow_sse.h
+++ b/src/pow_sse.h
@@ -2,6 +2,7 @@
 #define POW_SSE_H_
 
 #include "trinary.h"
+#include "common.h"
 #include "constants.h"
 #include <stdint.h>
 #include <pthread.h>
@@ -35,8 +36,8 @@ struct _pow_sse_context {
     int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
-    /* PoW-related result */
-    uint64_t hash_count;
+    /* PoW-related information */
+    PoW_Info *pow_info;
 };
 
 bool PowSSE(void *pow_ctx);

--- a/src/pow_sse.h
+++ b/src/pow_sse.h
@@ -35,6 +35,8 @@ struct _pow_sse_context {
     int8_t input_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int8_t output_trytes[TRANSACTION_TRYTES_LENGTH]; /* 2673 */
     int mwm;
+    /* PoW-related result */
+    uint64_t hash_count;
 };
 
 bool PowSSE(void *pow_ctx);

--- a/tests/common.h
+++ b/tests/common.h
@@ -19,8 +19,9 @@
 #include "pow_cl.h"
 #endif
 
-#include <stdlib.h>
+#include <inttypes.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/test-pow.c
+++ b/tests/test-pow.c
@@ -98,7 +98,7 @@ int main()
         PoWFPGAAccel_Context,
 #endif
     };
-
+    PoW_Info pow_info; 
 
     for (int idx = 0; idx < sizeof(ImplContextArr) / sizeof(ImplContext); idx++) {
         printf("%s\n",description[idx]);
@@ -112,10 +112,10 @@ int main()
         doThePoW(PoW_Context_ptr, pow_ctx);
         int8_t *ret_trytes = getPoWResult(PoW_Context_ptr, pow_ctx);
         assert(ret_trytes);
-#if defined(ENABLE_STAT)
         PoW_Info *info = (PoW_Info *) getPoWInfo(PoW_Context_ptr, pow_ctx);
-        printf("Hash count: %"PRIu64"\n", info->hash_count);
-#endif
+        assert(info);
+        pow_info.time = info->time;
+        pow_info.hash_count = info->hash_count;
         freePoWContext(PoW_Context_ptr, pow_ctx);
         destroyImplContext(PoW_Context_ptr);
 
@@ -136,6 +136,11 @@ int main()
         freeTrobject(hash_trytes);
         freeTrobject(ret_trits);
 
+#if defined(ENABLE_STAT)
+        printf("Hash count: %"PRIu64"\n", pow_info.hash_count);
+        printf("PoW execution time: %.0lf sec\n", pow_info.time);
+        printf("Hash rate: %.3lf kH/sec\n", pow_info.hash_count / pow_info.time / 1000);
+#endif
         printf("Success.\n");
     }
 

--- a/tests/test-pow.c
+++ b/tests/test-pow.c
@@ -112,6 +112,9 @@ int main()
         doThePoW(PoW_Context_ptr, pow_ctx);
         int8_t *ret_trytes = getPoWResult(PoW_Context_ptr, pow_ctx);
         assert(ret_trytes);
+#if defined(ENABLE_STAT)
+        printf("Hash count: %"PRIu64"\n", getHashCount(PoW_Context_ptr, pow_ctx));
+#endif
         freePoWContext(PoW_Context_ptr, pow_ctx);
         destroyImplContext(PoW_Context_ptr);
 

--- a/tests/test-pow.c
+++ b/tests/test-pow.c
@@ -113,7 +113,8 @@ int main()
         int8_t *ret_trytes = getPoWResult(PoW_Context_ptr, pow_ctx);
         assert(ret_trytes);
 #if defined(ENABLE_STAT)
-        printf("Hash count: %"PRIu64"\n", getHashCount(PoW_Context_ptr, pow_ctx));
+        PoW_Info *info = (PoW_Info *) getPoWInfo(PoW_Context_ptr, pow_ctx);
+        printf("Hash count: %"PRIu64"\n", info->hash_count);
 #endif
         freePoWContext(PoW_Context_ptr, pow_ctx);
         destroyImplContext(PoW_Context_ptr);


### PR DESCRIPTION
Calculate and sum the total `hash count` mentioned in #47 in `doThePoW` function.

The FPGA part will be implemented by @ajblane .

The `BUILD_BENCH` option and PoW execution time for hash rate will be added in the future pull requests.

2018/09/23: The `BUILD_BENCH` option has been added in `Makefile`.