### PR TITLE
Print the range including 95% of the hash rate values

### DIFF
--- a/tests/common.h
+++ b/tests/common.h
@@ -19,7 +19,6 @@
 #include "pow_cl.h"
 #endif
 
-#include <inttypes.h>
 #include <stdint.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
Implement functions of getting the average value and standard deviation.
Print the hash rate range when the `BUILD_STAT` option is enabled.
Close #77.

-----

The output message with `BUILD_STAT` option enabled would look like this:
```
Hash rate average value: XXXX.XXX kH/sec
with the range +- xxx.xxx kH/sec including 95% of the hash rate values.
```