### PR TITLE
Support "--pow-threads" command line option of IRI

### DIFF
--- a/jni/iri-pearldiver-exlib.c
+++ b/jni/iri-pearldiver-exlib.c
@@ -16,7 +16,8 @@ JNIEXPORT jboolean JNICALL
 Java_com_iota_iri_hash_PearlDiver_exlib_1search(JNIEnv *env,
                                                 jclass clazz,
                                                 jbyteArray trits,
-                                                jint mwm)
+                                                jint mwm,
+                                                jint threads)
 {
     /*********** Get the Byte array from Java byte Array *************/
     jbyte *c_trits = (*env)->GetByteArrayElements(env, trits, NULL);
@@ -27,7 +28,7 @@ Java_com_iota_iri_hash_PearlDiver_exlib_1search(JNIEnv *env,
         return JNI_FALSE;
     /****************************************************************/
 
-    int8_t *result = dcurl_entry(arg_trytes->data, mwm);
+    int8_t *result = dcurl_entry(arg_trytes->data, mwm, threads);
 
     /************ Write result back Java byte array *****************/
     Trytes_t *ret_trytes = initTrytes(result, 2673);

--- a/src/compat-ccurl.c
+++ b/src/compat-ccurl.c
@@ -21,7 +21,7 @@ char *ccurl_pow(char *trytes, int mwm)
         isInitialized = true;
     }
     pthread_mutex_unlock(&mtx);
-    return (char *) dcurl_entry((int8_t *) trytes, mwm);
+    return (char *) dcurl_entry((int8_t *) trytes, mwm, 1);
 }
 
 void ccurl_pow_finalize(void)

--- a/src/dcurl.c
+++ b/src/dcurl.c
@@ -98,7 +98,7 @@ void dcurl_destroy()
 }
 
 
-int8_t *dcurl_entry(int8_t *trytes, int mwm)
+int8_t *dcurl_entry(int8_t *trytes, int mwm, int threads)
 {
     void *pow_ctx = NULL;
     int8_t *res = NULL;
@@ -112,7 +112,7 @@ int8_t *dcurl_entry(int8_t *trytes, int mwm)
         list_for_each(p, &IMPL_LIST) {
             impl = list_entry(p, ImplContext, list);
             if (enterImplContext(impl)) {
-                pow_ctx = getPoWContext(impl, trytes, mwm);
+                pow_ctx = getPoWContext(impl, trytes, mwm, threads);
                 goto pow;
             }
         }

--- a/src/dcurl.h
+++ b/src/dcurl.h
@@ -6,6 +6,6 @@
 
 bool dcurl_init();
 void dcurl_destroy();
-int8_t *dcurl_entry(int8_t *trytes, int mwm);
+int8_t *dcurl_entry(int8_t *trytes, int mwm, int threads);
 
 #endif

--- a/src/implcontext.c
+++ b/src/implcontext.c
@@ -45,9 +45,9 @@ void exitImplContext(ImplContext *impl_ctx)
     pthread_mutex_unlock(&impl_ctx->lock);
 }
 
-void *getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm)
+void *getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm, int threads)
 {
-    return impl_ctx->getPoWContext(impl_ctx, trytes, mwm);
+    return impl_ctx->getPoWContext(impl_ctx, trytes, mwm, threads);
 }
 
 bool doThePoW(ImplContext *impl_ctx, void *pow_ctx)

--- a/src/implcontext.h
+++ b/src/implcontext.h
@@ -23,7 +23,7 @@ struct _impl_context {
     bool (*initialize)(ImplContext *impl_ctx);
     void (*destroy)(ImplContext *impl_ctx);
     /* Private PoW Context for each thread */
-    void *(*getPoWContext)(ImplContext *impl_ctx, int8_t *trytes, int mwm);
+    void *(*getPoWContext)(ImplContext *impl_ctx, int8_t *trytes, int mwm, int threads);
     bool (*doThePoW)(void *pow_ctx);
     int8_t *(*getPoWResult)(void *pow_ctx);
     PoW_Info (*getPoWInfo)(void *pow_ctx);
@@ -38,7 +38,7 @@ bool initializeImplContext(ImplContext *impl_ctx);
 void destroyImplContext(ImplContext *impl_ctx);
 bool enterImplContext(ImplContext *impl_ctx);
 void exitImplContext(ImplContext *impl_ctx);
-void *getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm);
+void *getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm, int threads);
 bool doThePoW(ImplContext *impl_ctx, void *pow_ctx);
 bool freePoWContext(ImplContext *impl_ctx, void *pow_ctx);
 int8_t *getPoWResult(ImplContext *impl_ctx, void *pow_ctx);

--- a/src/pow_avx.c
+++ b/src/pow_avx.c
@@ -577,7 +577,7 @@ static bool PoWAVX_Context_Initialize(ImplContext *impl_ctx)
         for (int j = 0; j < nproc; j++)
             ctx[i].nonce_array[j] = (int8_t *) (nonce_chunk + i * NONCE_TRITS_LENGTH * nproc +
                                                 j * NONCE_TRITS_LENGTH);
-        ctx[i].num_threads = nproc;
+        ctx[i].num_max_threads = nproc;
         impl_ctx->bitmap = impl_ctx->bitmap << 1 | 0x1;
     }
     impl_ctx->context = ctx;
@@ -603,7 +603,7 @@ static void PoWAVX_Context_Destroy(ImplContext *impl_ctx)
     free(ctx);
 }
 
-static void *PoWAVX_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm)
+static void *PoWAVX_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm, int threads)
 {
     pthread_mutex_lock(&impl_ctx->lock);
     for (int i = 0; i < impl_ctx->num_max_thread; i++) {
@@ -614,6 +614,10 @@ static void *PoWAVX_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm
             memcpy(ctx->input_trytes, trytes, TRANSACTION_TRYTES_LENGTH);
             ctx->mwm = mwm;
             ctx->indexOfContext = i;
+            if (threads > 0 && threads < ctx->num_max_threads)
+                ctx->num_threads = threads;
+            else
+                ctx->num_threads = ctx->num_max_threads;
             return ctx;
         }
     }

--- a/src/pow_avx.h
+++ b/src/pow_avx.h
@@ -30,6 +30,7 @@ struct _pow_avx_context {
     int8_t **nonce_array;
     int stopPoW;
     int num_threads;
+    int num_max_threads;
     /* Management of Multi-thread */
     int indexOfContext;
     /* Arguments of PoW */

--- a/src/pow_c.c
+++ b/src/pow_c.c
@@ -337,7 +337,7 @@ static bool PoWC_Context_Initialize(ImplContext *impl_ctx)
         for (int j = 0; j < nproc; j++)
             ctx[i].nonce_array[j] = (int8_t *) (nonce_chunk + i * NONCE_TRITS_LENGTH * nproc +
                                                 j * NONCE_TRITS_LENGTH);
-        ctx[i].num_threads = nproc;
+        ctx[i].num_max_threads = nproc;
         impl_ctx->bitmap = impl_ctx->bitmap << 1 | 0x1;
     }
     impl_ctx->context = ctx;
@@ -363,7 +363,7 @@ static void PoWC_Context_Destroy(ImplContext *impl_ctx)
     free(ctx);
 }
 
-static void *PoWC_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm)
+static void *PoWC_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm, int threads)
 {
     pthread_mutex_lock(&impl_ctx->lock);
     for (int i = 0; i < impl_ctx->num_max_thread; i++) {
@@ -374,6 +374,10 @@ static void *PoWC_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm)
             memcpy(ctx->input_trytes, trytes, TRANSACTION_TRYTES_LENGTH);
             ctx->mwm = mwm;
             ctx->indexOfContext = i;
+            if (threads > 0 && threads < ctx->num_max_threads)
+                ctx->num_threads = threads;
+            else
+                ctx->num_threads = ctx->num_max_threads;
             return ctx;
         }
     }

--- a/src/pow_c.h
+++ b/src/pow_c.h
@@ -31,6 +31,7 @@ struct _pow_c_context {
     int8_t **nonce_array;
     int stopPoW;
     int num_threads;
+    int num_max_threads;
     /* Management of Multi-thread */
     int indexOfContext;
     /* Arguments of PoW */

--- a/src/pow_cl.c
+++ b/src/pow_cl.c
@@ -270,7 +270,7 @@ static void PoWCL_Context_Destroy(ImplContext *impl_ctx)
     free(ctx);
 }
 
-static void *PoWCL_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm)
+static void *PoWCL_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm, int threads)
 {
     pthread_mutex_lock(&impl_ctx->lock);
     for (int i = 0; i < impl_ctx->num_max_thread; i++) {

--- a/src/pow_fpga_accel.c
+++ b/src/pow_fpga_accel.c
@@ -199,7 +199,8 @@ static void PoWFPGAAccel_Context_Destroy(ImplContext *impl_ctx)
 
 static void *PoWFPGAAccel_getPoWContext(ImplContext *impl_ctx,
                                         int8_t *trytes,
-                                        int mwm)
+                                        int mwm,
+                                        int threads)
 {
     PoW_FPGA_Accel_Context *ctx = impl_ctx->context;
     memcpy(ctx->input_trytes, trytes, TRANSACTION_TRYTES_LENGTH);

--- a/src/pow_sse.c
+++ b/src/pow_sse.c
@@ -354,7 +354,7 @@ static bool PoWSSE_Context_Initialize(ImplContext *impl_ctx)
         for (int j = 0; j < nproc; j++)
             ctx[i].nonce_array[j] = (int8_t *) (nonce_chunk + i * NONCE_TRITS_LENGTH * nproc +
                                                 j * NONCE_TRITS_LENGTH);
-        ctx[i].num_threads = nproc;
+        ctx[i].num_max_threads = nproc;
         impl_ctx->bitmap = impl_ctx->bitmap << 1 | 0x1;
     }
     impl_ctx->context = ctx;
@@ -380,7 +380,7 @@ static void PoWSSE_Context_Destroy(ImplContext *impl_ctx)
     free(ctx);
 }
 
-static void *PoWSSE_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm)
+static void *PoWSSE_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm, int threads)
 {
     pthread_mutex_lock(&impl_ctx->lock);
     for (int i = 0; i < impl_ctx->num_max_thread; i++) {
@@ -391,6 +391,10 @@ static void *PoWSSE_getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm
             memcpy(ctx->input_trytes, trytes, TRANSACTION_TRYTES_LENGTH);
             ctx->mwm = mwm;
             ctx->indexOfContext = i;
+            if (threads > 0 && threads < ctx->num_max_threads)
+                ctx->num_threads = threads;
+            else
+                ctx->num_threads = ctx->num_max_threads;
             return ctx;
         }
     }

--- a/src/pow_sse.h
+++ b/src/pow_sse.h
@@ -30,6 +30,7 @@ struct _pow_sse_context {
     int8_t **nonce_array;
     int stopPoW;
     int num_threads;
+    int num_max_threads;
     /* Management of Multi-thread */
     int indexOfContext;
     /* Arguments of PoW */

--- a/tests/test-dcurl.c
+++ b/tests/test-dcurl.c
@@ -49,7 +49,7 @@ int main()
 
     /* test dcurl Implementation with mwm = 9 */
     dcurl_init();
-    int8_t *ret_trytes = dcurl_entry((int8_t *) trytes, mwm);
+    int8_t *ret_trytes = dcurl_entry((int8_t *) trytes, mwm, 0);
     assert(ret_trytes);
     dcurl_destroy();
 

--- a/tests/test-multi-pow.py
+++ b/tests/test-multi-pow.py
@@ -42,7 +42,7 @@ def validate(trytes, mwm):
 
 def call_dcurl(idx, mwm, lib, trytes_list):
     tmp = str(trytes_list[idx]).encode('ascii')
-    ret = lib.dcurl_entry(tmp, mwm)
+    ret = lib.dcurl_entry(tmp, mwm, 0)
     trytes = TryteString(ret[:2673])
 
     hash_trytes = hash(trytes)
@@ -56,7 +56,7 @@ def testing():
     # Settings of shared library
     libdcurl = ctypes.cdll.LoadLibrary(DCURL_PATH)
     #libdcurl.dcurl_init.argtypes = [ctypes.c_int, ctypes.c_int]
-    libdcurl.dcurl_entry.argtypes = [ctypes.c_char_p, ctypes.c_int]
+    libdcurl.dcurl_entry.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
     libdcurl.dcurl_entry.restype = ctypes.c_char_p
 
     libdcurl.dcurl_init()

--- a/tests/test-pow.c
+++ b/tests/test-pow.c
@@ -139,7 +139,7 @@ int main()
 
         /* test implementation with mwm = 14 */
         initializeImplContext(PoW_Context_ptr);
-        void *pow_ctx = getPoWContext(PoW_Context_ptr, (int8_t *) trytes, mwm);
+        void *pow_ctx = getPoWContext(PoW_Context_ptr, (int8_t *) trytes, mwm, 0);
         assert(pow_ctx);
 
         for (int count = 0; count < pow_total; count++) {


### PR DESCRIPTION
If the "--pow-threads" value is greater than 0 and less than the maximum available resources,
the number of threads would be equal to the "--pow-threads" value.
Otherwise, the number of threads would be set with the original mechanism.

The GPU and FPGA implementation are not affected by the "--pow-threads".

Close #86.