### PR TITLE
Fix memory double free error

### DIFF
--- a/src/dcurl.c
+++ b/src/dcurl.c
@@ -94,6 +94,7 @@ void dcurl_destroy()
     list_for_each(p, &IMPL_LIST) {
         impl = list_entry(p, ImplContext, list);
         destroyImplContext(impl);
+        list_del(p);
     }
 }
 

--- a/tests/test-dcurl.c
+++ b/tests/test-dcurl.c
@@ -2,6 +2,8 @@
 #include "common.h"
 #include "dcurl.h"
 
+#define LOOP_MAX 5
+
 int main()
 {
     char *trytes =
@@ -47,27 +49,29 @@ int main()
 
     int mwm = 9;
 
-    /* test dcurl Implementation with mwm = 9 */
-    dcurl_init();
-    int8_t *ret_trytes = dcurl_entry((int8_t *) trytes, mwm, 0);
-    assert(ret_trytes);
-    dcurl_destroy();
+    for (int loop_count = 0; loop_count < LOOP_MAX; loop_count++) {
+        /* test dcurl Implementation with mwm = 9 */
+        dcurl_init();
+        int8_t *ret_trytes = dcurl_entry((int8_t *) trytes, mwm, 0);
+        assert(ret_trytes);
+        dcurl_destroy();
 
-    Trytes_t *trytes_t = initTrytes(ret_trytes, 2673);
-    assert(trytes_t);
-    Trytes_t *hash_trytes = hashTrytes(trytes_t);
-    assert(hash_trytes);
+        Trytes_t *trytes_t = initTrytes(ret_trytes, 2673);
+        assert(trytes_t);
+        Trytes_t *hash_trytes = hashTrytes(trytes_t);
+        assert(hash_trytes);
 
-    /* Validation */
-    Trits_t *ret_trits = trits_from_trytes(hash_trytes);
-    for (int i = 243 - 1; i >= 243 - mwm; i--) {
-        assert(ret_trits->data[i] == 0);
+        /* Validation */
+        Trits_t *ret_trits = trits_from_trytes(hash_trytes);
+        for (int i = 243 - 1; i >= 243 - mwm; i--) {
+            assert(ret_trits->data[i] == 0);
+        }
+
+        free(ret_trytes);
+        freeTrobject(trytes_t);
+        freeTrobject(hash_trytes);
+        freeTrobject(ret_trits);
     }
-
-    free(ret_trytes);
-    freeTrobject(trytes_t);
-    freeTrobject(hash_trytes);
-    freeTrobject(ret_trits);
 
     return 0;
 }


### PR DESCRIPTION
The memory double free error occurs if we initialize and destroy dcurl repeatedly.
dcurl maintains a list of nodes for different hardwares.
The error is caused by forgetting to remove the nodes from the list.
To fix it, add the corresponding function list_del() in dcurl_destroy().

Besides fixing the error, one of the testcases is modified
to repeatedly test the initialization and destruction of dcurl N times.
The value of N equals to 5.

Close #94.