### PR TITLE
Enable building FPGA or GPU platform independently

### DIFF
--- a/docs/build-n-test.md
+++ b/docs/build-n-test.md
@@ -13,18 +13,23 @@
 ## Build Instructions
 * dcurl allows various combinations of build configurations to fit final use scenarios.
 * You can execute `make config` and then edit file `build/local.mk` for custom build options.
-    - ``BUILD_AVX``: build Intel AVX-accelerated Curl backend.
-    - ``BUILD_GPU``: build OpenCL-based GPU accelerations.
+    - ``BUILD_AVX``: build the Intel AVX-accelerated Curl backend.
+    - ``BUILD_SSE``: build the Intel SSE-accelerated Curl backend.
+    - ``BUILD_GPU``: build the OpenCL-based GPU accelerations.
+    - ``BUILD_FPGA_ACCEL``: build the interface interacting with the Cyclone V FPGA based accelerator. Verified on DE10-nano board and Arrow SoCKit board.
     - ``BUILD_JNI``: build a shared library for IRI. The build system would generate JNI header file
                      downloading from [latest JAVA source](https://github.com/DLTcollab/iri).
     - ``BUILD_COMPAT``: build extra cCurl compatible interface.
-    - ``BUILD_FPGA_ACCEL``: build the interface interacting with the Cyclone V FPGA based accelerator. Verified on DE10-nano board and Arrow SoCKit board.
     - ``BUILD_STAT``: show the statistics of the PoW information.
     - ``BUILD_DEBUG``: dump verbose messages internally.
 * Alternatively, you can specify conditional build as following:
 ```shell
 $ make BUILD_GPU=0 BUILD_JNI=1 BUILD_AVX=1
 ```
+
+## Fallback Build Instructions
+* These instructions do not appear in the file `build/local.mk`.
+    - ``BUILD_GENERIC``: build the generic CPU Curl backend without acceleration.
 
 ## Testing and Validation
 * Test with GPU

--- a/mk/defs.mk
+++ b/mk/defs.mk
@@ -4,17 +4,20 @@ BUILD_DEBUG ?= 0
 # Build AVX backend or not
 BUILD_AVX ?= 0
 
+# Build SSE backend or not
+BUILD_SSE ?= 0
+
 # Build OpenCL backend or not
 BUILD_GPU ?= 0
+
+# Build FPGA backend or not
+BUILD_FPGA_ACCEL ?= 0
 
 # Build JNI glue as the bridge between dcurl and IRI
 BUILD_JNI ?= 0
 
 # Build cCurl compatible interface
 BUILD_COMPAT ?= 0
-
-# Build FPGA backend or not
-BUILD_FPGA_ACCEL ?= 0
 
 # Show the PoW-related statistic messages or not
 BUILD_STAT ?= 0

--- a/src/dcurl.c
+++ b/src/dcurl.c
@@ -21,7 +21,7 @@
 #include "pow_avx.h"
 #elif defined(ENABLE_SSE)
 #include "pow_sse.h"
-#else
+#elif defined(ENABLE_GENERIC)
 #include "pow_c.h"
 #endif
 
@@ -46,7 +46,7 @@ LIST_HEAD(IMPL_LIST);
 extern ImplContext PoWAVX_Context;
 #elif defined(ENABLE_SSE)
 extern ImplContext PoWSSE_Context;
-#else
+#elif defined(ENABLE_GENERIC)
 extern ImplContext PoWC_Context;
 #endif
 
@@ -66,7 +66,7 @@ bool dcurl_init()
     ret &= registerImplContext(&PoWAVX_Context);
 #elif defined(ENABLE_SSE)
     ret &= registerImplContext(&PoWSSE_Context);
-#else
+#elif defined(ENABLE_GENERIC)
     ret &= registerImplContext(&PoWC_Context);
 #endif
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -9,14 +9,15 @@
 #include "pow_avx.h"
 #elif defined(ENABLE_SSE)
 #include "pow_sse.h"
-#elif defined(ENABLE_FPGA_ACCEL)
-#include "pow_fpga_accel.h"
-#else
+#elif defined(ENABLE_GENERIC)
 #include "pow_c.h"
 #endif
 
 #if defined(ENABLE_OPENCL)
 #include "pow_cl.h"
+#endif
+#if defined(ENABLE_FPGA_ACCEL)
+#include "pow_fpga_accel.h"
 #endif
 
 #include <stdint.h>

--- a/tests/test-pow.c
+++ b/tests/test-pow.c
@@ -9,7 +9,7 @@
 extern ImplContext PoWAVX_Context;
 #elif defined(ENABLE_SSE)
 extern ImplContext PoWSSE_Context;
-#else
+#elif defined(ENABLE_GENERIC)
 extern ImplContext PoWC_Context;
 #endif
 
@@ -26,7 +26,7 @@ const char *description[] = {
     "CPU - AVX",
 #elif defined(ENABLE_SSE)
     "CPU - SSE",
-#else
+#elif defined(ENABLE_GENERIC)
     "CPU - pure C",
 #endif
 
@@ -114,7 +114,7 @@ int main()
         PoWAVX_Context,
 #elif defined(ENABLE_SSE)
         PoWSSE_Context,
-#else
+#elif defined(ENABLE_GENERIC)
         PoWC_Context,
 #endif
 


### PR DESCRIPTION
The original building process would compile CPU-related code as well
even if we assign the other platform(GPU or FPGA) only.

The current building process can build each platform independently.
If no hardware platform is specified,
the CPU and the supported instruction set would be chose.
The libtuv code would be compiled only if the specified hardware
platforms contain CPU.

Close #105.