### PR TITLE
fix: fix the returned value of finding nonce value

### DIFF
--- a/src/pow_c.c
+++ b/src/pow_c.c
@@ -121,7 +121,7 @@ static long long int loop_cpu(uint64_t *lmid,
             return i * 64;
         }
     }
-    return -i * 64 + 1;
+    return -i * 64 - 1;
 }
 
 static void para(int8_t in[], uint64_t l[], uint64_t h[])


### PR DESCRIPTION
If the thread finds the legal nonce value,
it should always return a positive or zero value.
Otherwise, it should always return a negative value.

Close #108.