### PR TITLE
Build: Extend build option for Sanitizer checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,14 @@ endif
 
 -include $(OUT)/local.mk
 
-ifeq ("$(BUILD_DEBUG)","1")
-CFLAGS += -Og -g3 -DENABLE_DEBUG
+ifneq ("$(BUILD_DEBUG)","0")
+    CFLAGS += -Og -g3 -DENABLE_DEBUG
+    ifneq ("$(BUILD_DEBUG)","1")
+        include mk/sanitizers.mk
+    endif
 else
-# Enable all the valid optimizations for standard programs in release build
-CFLAGS += -O3
+    # Enable all the valid optimizations for standard programs in release build
+    CFLAGS += -O3
 endif
 
 # Check specific CPU features available on build host

--- a/docs/build-n-test.md
+++ b/docs/build-n-test.md
@@ -22,6 +22,7 @@
     - ``BUILD_COMPAT``: build extra cCurl compatible interface.
     - ``BUILD_STAT``: show the statistics of the PoW information.
     - ``BUILD_DEBUG``: dump verbose messages internally.
+                       Build with the corresponding Sanitizer to detect software potential bugs if the value is `address`, `undefined` or `thread`.
 * Alternatively, you can specify conditional build as following:
 ```shell
 $ make BUILD_GPU=0 BUILD_JNI=1 BUILD_AVX=1

--- a/mk/defs.mk
+++ b/mk/defs.mk
@@ -1,4 +1,10 @@
-# Debug or release build
+# Debug, debug + Sanitizer or release build
+# Acceptable values
+# 0: release build
+# 1: debug build
+# address: debug build + address Sanitizer
+# undefined: debug build + undefined behavior Sanitizer
+# thread: debug build + thread Sanitizer
 BUILD_DEBUG ?= 0
 
 # Build AVX backend or not

--- a/mk/sanitizers.mk
+++ b/mk/sanitizers.mk
@@ -1,0 +1,21 @@
+SHELL = /bin/bash
+
+# Check whether the GCC version is higher than the minimum required version including Sanitizers
+# TODO: The ARM platform should be handled as well
+SANITIZER_MIN_GCC_VER = 4.9
+GCC_VER := $(shell $(CC) -dumpfullversion)
+# Get the lower version of the current GCC version and the minimum required version
+LOWER_VER := $(firstword $(shell echo -e "$(SANITIZER_MIN_GCC_VER)\n$(GCC_VER)" | sort -V))
+
+# Check whether the specified Sanitizer is existed or not
+SANITIZER_LIST = address undefined thread
+# If it is existed, return the name of the Sanitizer
+# Otherwise, return empty string
+SANITIZER := $(filter $(SANITIZER_LIST),$(BUILD_DEBUG))
+
+ifeq ("$(LOWER_VER)","$(SANITIZER_MIN_GCC_VER)")
+    ifneq ("$(SANITIZER)","")
+        CFLAGS += -fsanitize=$(SANITIZER)
+        LDFLAGS += -fsanitize=$(SANITIZER)
+    endif
+endif


### PR DESCRIPTION
The extended and acceptable value of `BUILD_DEBUG` are
- 0: release build
- 1: debug build
- address: debug build + address Sanitizer
- undefined: debug build + undefined behavior Sanitizer
- thread: debug build + thread Sanitizer
If the unacceptable value is inputted, it would be debug build only.

The file mk/sanitizers.mk handles the GCC version validation
and filters out the invalid BUILD_DEBUG option.