### PR TITLE
build: Allow libtuv to be built on other ARM boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,14 +131,6 @@ endif
 
 OBJS := $(addprefix $(OUT)/, $(OBJS))
 
-# Add the libtuv PIC(position independent code) library into the object files
-# if the specified hardware is CPU
-CPU_PLATFORMS := $(BUILD_AVX) $(BUILD_SSE) $(BUILD_GENERIC)
-ENABLE_CPU_PLATFORMS := $(findstring 1,$(CPU_PLATFORMS))
-ifeq ("$(ENABLE_CPU_PLATFORMS)","1")
-    OBJS += $(LIBTUV_LIBRARY)
-endif
-
 $(OUT)/test-%.o: tests/test-%.c $(LIBTUV_PATH)/include
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) -I $(SRC) $(LIBTUV_INCLUDE) -c -MMD -MF $@.d $<
@@ -147,11 +139,11 @@ $(OUT)/%.o: $(SRC)/%.c $(LIBTUV_PATH)/include
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) $(LIBTUV_INCLUDE) -c -MMD -MF $@.d $<
 
-$(OUT)/test-%: $(OUT)/test-%.o $(OBJS)
+$(OUT)/test-%: $(OUT)/test-%.o $(OBJS) $(LIBTUV_LIBRARY)
 	$(VECHO) "  LD\t$@\n"
 	$(Q)$(CC) -o $@ $^ $(LDFLAGS)
 
-$(OUT)/libdcurl.so: $(OBJS)
+$(OUT)/libdcurl.so: $(OBJS) $(LIBTUV_LIBRARY)
 	$(VECHO) "  LD\t$@\n"
 	$(Q)$(CC) -shared -o $@ $^ $(LDFLAGS)
 

--- a/docs/build-n-test.md
+++ b/docs/build-n-test.md
@@ -23,6 +23,8 @@
     - ``BUILD_STAT``: show the statistics of the PoW information.
     - ``BUILD_DEBUG``: dump verbose messages internally.
                        Build with the corresponding Sanitizer to detect software potential bugs if the value is `address`, `undefined` or `thread`.
+    - ``BOARD``: specify the board which builds the source code.
+                 The supported boards are `de10nano` (DE10-nano board), `arrowsockit` (Arrow SoCKit board), `rpi2` and `rpi3` (Raspberry Pi 2/3 board).
 * Alternatively, you can specify conditional build as following:
 ```shell
 $ make BUILD_GPU=0 BUILD_JNI=1 BUILD_AVX=1

--- a/mk/submodule.mk
+++ b/mk/submodule.mk
@@ -8,11 +8,16 @@ ifeq ($(UNAME_S),Darwin)
     # macOS
     UNAME_S := darwin
 endif
+# For de10-nano, arrow sockit and raspberry pi 2/3 board
+ifeq ($(UNAME_M),armv7l)
+    UNAME_M := arm
+endif
 
 # libtuv related variables
 LIBTUV_PATH = deps/libtuv
 LIBTUV_INCLUDE := -I $(LIBTUV_PATH)/include
 LIBTUV_PLATFORM := $(UNAME_M)-$(UNAME_S)
+LIBTUV_BOARD := $(BUILD_BOARD)
 # PIC (Position-Independent-Code) library
 LIBTUV_LIBRARY := $(LIBTUV_PATH)/build/$(LIBTUV_PLATFORM)/release/lib/libtuv.o
 
@@ -20,4 +25,4 @@ $(LIBTUV_PATH)/include:
 	git submodule update --init $(LIBTUV_PATH)
 
 $(LIBTUV_LIBRARY):
-	$(MAKE) -C $(LIBTUV_PATH) TUV_BUILD_TYPE=release TUV_CREATE_PIC_LIB=yes
+	$(MAKE) -C $(LIBTUV_PATH) TUV_BUILD_TYPE=release TUV_CREATE_PIC_LIB=yes TUV_PLATFORM=$(LIBTUV_PLATFORM) TUV_BOARD=$(LIBTUV_BOARD)


### PR DESCRIPTION
The supported ARM boards are DE10-nano, Arrow SoCKit and Raspberry Pi 2/3 board.

Close #126.