### PR TITLE
feat: Make thread synchronization portable

### DIFF
--- a/src/implcontext.c
+++ b/src/implcontext.c
@@ -30,21 +30,21 @@ void destroyImplContext(ImplContext *impl_ctx)
 
 bool enterImplContext(ImplContext *impl_ctx)
 {
-    pthread_mutex_lock(&impl_ctx->lock);
+    uv_mutex_lock(&impl_ctx->lock);
     if (impl_ctx->num_working_thread >= impl_ctx->num_max_thread) {
-        pthread_mutex_unlock(&impl_ctx->lock);
+        uv_mutex_unlock(&impl_ctx->lock);
         return false; /* Access Failed */
     }
     impl_ctx->num_working_thread++;
-    pthread_mutex_unlock(&impl_ctx->lock);
+    uv_mutex_unlock(&impl_ctx->lock);
     return true; /* Access Success */
 }
 
 void exitImplContext(ImplContext *impl_ctx)
 {
-    pthread_mutex_lock(&impl_ctx->lock);
+    uv_mutex_lock(&impl_ctx->lock);
     impl_ctx->num_working_thread--;
-    pthread_mutex_unlock(&impl_ctx->lock);
+    uv_mutex_unlock(&impl_ctx->lock);
 }
 
 void *getPoWContext(ImplContext *impl_ctx, int8_t *trytes, int mwm, int threads)

--- a/src/implcontext.h
+++ b/src/implcontext.h
@@ -1,11 +1,11 @@
 #ifndef IMPL_CTX_H_
 #define IMPL_CTX_H_
 
-#include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "common.h"
 #include "list.h"
+#include "uv.h"
 
 typedef struct _impl_context ImplContext;
 
@@ -14,7 +14,7 @@ struct _impl_context {
     char *description;
 
     /* Multi-thread Management */
-    pthread_mutex_t lock;
+    uv_mutex_t lock;
     int bitmap; /* Used to tell which slot is available */
     int num_max_thread;
     int num_working_thread;

--- a/src/pow_avx.c
+++ b/src/pow_avx.c
@@ -6,11 +6,9 @@
  */
 
 #include "pow_avx.h"
-#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <uv.h>
 #include "cpu-utils.h"
 #include "curl.h"
 #include "implcontext.h"
@@ -610,7 +608,7 @@ static bool PoWAVX_Context_Initialize(ImplContext *impl_ctx)
         uv_loop_init(&ctx[i].loop);
     }
     impl_ctx->context = ctx;
-    pthread_mutex_init(&impl_ctx->lock, NULL);
+    uv_mutex_init(&impl_ctx->lock);
     return true;
 
 fail:
@@ -643,11 +641,11 @@ static void *PoWAVX_getPoWContext(ImplContext *impl_ctx,
                                   int mwm,
                                   int threads)
 {
-    pthread_mutex_lock(&impl_ctx->lock);
+    uv_mutex_lock(&impl_ctx->lock);
     for (int i = 0; i < impl_ctx->num_max_thread; i++) {
         if (impl_ctx->bitmap & (0x1 << i)) {
             impl_ctx->bitmap &= ~(0x1 << i);
-            pthread_mutex_unlock(&impl_ctx->lock);
+            uv_mutex_unlock(&impl_ctx->lock);
             PoW_AVX_Context *ctx =
                 impl_ctx->context + sizeof(PoW_AVX_Context) * i;
             memcpy(ctx->input_trytes, trytes, TRANSACTION_TRYTES_LENGTH);
@@ -660,15 +658,15 @@ static void *PoWAVX_getPoWContext(ImplContext *impl_ctx,
             return ctx;
         }
     }
-    pthread_mutex_unlock(&impl_ctx->lock);
+    uv_mutex_unlock(&impl_ctx->lock);
     return NULL; /* It should not happen */
 }
 
 static bool PoWAVX_freePoWContext(ImplContext *impl_ctx, void *pow_ctx)
 {
-    pthread_mutex_lock(&impl_ctx->lock);
+    uv_mutex_lock(&impl_ctx->lock);
     impl_ctx->bitmap |= 0x1 << ((PoW_AVX_Context *) pow_ctx)->indexOfContext;
-    pthread_mutex_unlock(&impl_ctx->lock);
+    uv_mutex_unlock(&impl_ctx->lock);
     return true;
 }
 

--- a/src/pow_avx.h
+++ b/src/pow_avx.h
@@ -1,13 +1,12 @@
 #ifndef POW_AVX_H_
 #define POW_AVX_H_
 
-#include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <uv.h>
 #include "common.h"
 #include "constants.h"
 #include "trinary.h"
+#include "uv.h"
 
 typedef struct _pwork_struct Pwork_struct;
 

--- a/src/pow_c.h
+++ b/src/pow_c.h
@@ -1,13 +1,12 @@
 #ifndef POW_C_H_
 #define POW_C_H_
 
-#include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <uv.h>
 #include "common.h"
 #include "constants.h"
 #include "trinary.h"
+#include "uv.h"
 
 typedef struct _pwork_struct Pwork_struct;
 

--- a/src/pow_fpga_accel.c
+++ b/src/pow_fpga_accel.c
@@ -163,7 +163,6 @@ static bool PoWFPGAAccel_Context_Initialize(ImplContext *impl_ctx)
     ctx->cpow_map = (uint32_t *) (ctx->fpga_regs_map + CPOW_BASE);
 
     impl_ctx->context = ctx;
-    pthread_mutex_init(&impl_ctx->lock, NULL);
 
     return true;
 

--- a/src/pow_sse.c
+++ b/src/pow_sse.c
@@ -7,11 +7,9 @@
 
 #include "pow_sse.h"
 #include <inttypes.h>
-#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <uv.h>
 #include "cpu-utils.h"
 #include "curl.h"
 #include "implcontext.h"
@@ -392,7 +390,7 @@ static bool PoWSSE_Context_Initialize(ImplContext *impl_ctx)
         uv_loop_init(&ctx[i].loop);
     }
     impl_ctx->context = ctx;
-    pthread_mutex_init(&impl_ctx->lock, NULL);
+    uv_mutex_init(&impl_ctx->lock);
     return true;
 
 fail:
@@ -425,11 +423,11 @@ static void *PoWSSE_getPoWContext(ImplContext *impl_ctx,
                                   int mwm,
                                   int threads)
 {
-    pthread_mutex_lock(&impl_ctx->lock);
+    uv_mutex_lock(&impl_ctx->lock);
     for (int i = 0; i < impl_ctx->num_max_thread; i++) {
         if (impl_ctx->bitmap & (0x1 << i)) {
             impl_ctx->bitmap &= ~(0x1 << i);
-            pthread_mutex_unlock(&impl_ctx->lock);
+            uv_mutex_unlock(&impl_ctx->lock);
             PoW_SSE_Context *ctx =
                 impl_ctx->context + sizeof(PoW_SSE_Context) * i;
             memcpy(ctx->input_trytes, trytes, TRANSACTION_TRYTES_LENGTH);
@@ -442,15 +440,15 @@ static void *PoWSSE_getPoWContext(ImplContext *impl_ctx,
             return ctx;
         }
     }
-    pthread_mutex_unlock(&impl_ctx->lock);
+    uv_mutex_unlock(&impl_ctx->lock);
     return NULL; /* It should not happen */
 }
 
 static bool PoWSSE_freePoWContext(ImplContext *impl_ctx, void *pow_ctx)
 {
-    pthread_mutex_lock(&impl_ctx->lock);
+    uv_mutex_lock(&impl_ctx->lock);
     impl_ctx->bitmap |= 0x1 << ((PoW_SSE_Context *) pow_ctx)->indexOfContext;
-    pthread_mutex_unlock(&impl_ctx->lock);
+    uv_mutex_unlock(&impl_ctx->lock);
     return true;
 }
 

--- a/src/pow_sse.h
+++ b/src/pow_sse.h
@@ -1,13 +1,12 @@
 #ifndef POW_SSE_H_
 #define POW_SSE_H_
 
-#include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <uv.h>
 #include "common.h"
 #include "constants.h"
 #include "trinary.h"
+#include "uv.h"
 
 typedef struct _pwork_struct Pwork_struct;
 


### PR DESCRIPTION
Replace the thread synchronization functions with the portable
libtuv APIs and remove the unused code.

TODO:
Make mutex of src/compat-ccurl.c portable.

Close #107.