### PR TITLE
Jar create and extract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ docs/html
 *.obj
 *.elf
 
-# Precompiled Headers
+# Precompiled headers
 *.gch
 *.pch
 
@@ -23,3 +23,6 @@ docs/html
 *.so
 *.so.*
 *.dylib
+
+# Java bytecode
+*.class

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION = 0.2.0
+
 OUT ?= ./build
 SRC := src
 
@@ -89,7 +91,15 @@ TESTS := $(addprefix $(OUT)/test-, $(TESTS))
 LIBS = libdcurl.so
 LIBS := $(addprefix $(OUT)/, $(LIBS))
 
-all: config $(TESTS) $(LIBS)
+JARS := dcurljni-$(VERSION).jar
+JARS := $(addprefix $(OUT)/, $(JARS))
+
+PREQ := config $(TESTS) $(LIBS)
+ifeq ("$(BUILD_JNI)","1")
+PREQ += $(JARS)
+endif
+
+all: $(PREQ)
 .DEFAULT_GOAL := all
 
 OBJS = \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dcurl - Multi-threaded Curl implementation
 
 [![Build Status](https://badge.buildkite.com/46ec07b122bde13f984c241fe8b38e64698c5c0d816ee6c7e4.svg)](https://buildkite.com/dltcollab/dcurl-test)
-![Supported IRI version](https://img.shields.io/badge/Supported%20IRI%20Version-1.6.0-brightgreen.svg)
+![Supported IRI version](https://img.shields.io/badge/Supported%20IRI%20Version-1.7.0-brightgreen.svg)
 ![Release version](https://img.shields.io/github/release-pre/DLTcollab/dcurl.svg)
 
 Hardware-accelerated implementation for IOTA PearlDiver, which utilizes multi-threaded SIMD, FPGA and GPU.
@@ -28,7 +28,13 @@ After integrating dcurl into IRI, performance of [attachToTangle](https://iota.r
 
 ## IRI Adaptation
 [Modified IRI accepting external PoW Library](https://github.com/DLTcollab/iri)
-Supported IRI version: 1.6.0
+Supported IRI version: 1.7.0
+
+* ```$ cd ~/iri && mvn compile && mvn package```
+* ```$ java -jar target/iri.jar -p <port> --pearldiver-exlib dcurl```
+
+or with the **deprecated** commands
+
 * ```$ cd ~/iri && mvn compile && mvn package```
 * ```$ cp ~/dcurl/build/libdcurl.so ~/iri```
 * ```$ cd ~/iri && java -Djava.library.path=./ -jar target/iri.jar -p <port> --pearldiver-exlib dcurl```

--- a/docs/build-n-test.md
+++ b/docs/build-n-test.md
@@ -17,7 +17,7 @@
     - ``BUILD_SSE``: build the Intel SSE-accelerated Curl backend.
     - ``BUILD_GPU``: build the OpenCL-based GPU accelerations.
     - ``BUILD_FPGA_ACCEL``: build the interface interacting with the Cyclone V FPGA based accelerator. Verified on DE10-nano board and Arrow SoCKit board.
-    - ``BUILD_JNI``: build a shared library for IRI. The build system would generate JNI header file
+    - ``BUILD_JNI``: build a JAR file including the shared library and the JAVA bytecode for IRI. The build system would generate JNI header file
                      downloading from [latest JAVA source](https://github.com/DLTcollab/iri).
     - ``BUILD_COMPAT``: build extra cCurl compatible interface.
     - ``BUILD_STAT``: show the statistics of the PoW information.

--- a/java/org/dltcollab/Dcurl.java
+++ b/java/org/dltcollab/Dcurl.java
@@ -1,0 +1,43 @@
+package org.dltcollab;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+public class Dcurl {
+    private static final String libraryName = "dcurl";
+    private static final String libraryPrefix = "lib";
+    private static final String librarySuffix = ".so";
+    private static final String libraryFileName = libraryPrefix + libraryName + librarySuffix;
+
+    public void loadLibraryFromJar() {
+        final File temp;
+        try {
+            temp = File.createTempFile(libraryPrefix + libraryName, librarySuffix);
+            if (temp.exists() && !temp.delete()) {
+                throw new RuntimeException("File: " + temp.getAbsolutePath() + " already exists and cannot be removed.");
+            }
+            if (!temp.createNewFile()) {
+                throw new RuntimeException("File: " + temp.getAbsolutePath() + " could not be created.");
+            }
+
+            if (!temp.exists()) {
+                throw new RuntimeException("File " + temp.getAbsolutePath() + " does not exist.");
+            } else {
+                temp.deleteOnExit();
+            }
+
+            // attempt to copy the library from the Jar file to the temp destination
+            try (final InputStream is = getClass().getClassLoader().getResourceAsStream(libraryFileName)) {
+                if (is == null) {
+                    throw new RuntimeException(libraryFileName + " was not found inside JAR.");
+                } else {
+                    Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+
+            System.load(temp.getAbsolutePath());
+        } catch (IOException e) {
+        }
+    }
+}


### PR DESCRIPTION
- feat: Create JAR file for Java native interface
Build with option `BUILD_JNI=1` would compile the Java code and create the JAR file.
The dcurl shared library `libdcurl.so` would be packaged into the JAR file
and can be extracted from it for Jave native interface easily.
Close #106.

- docs: Change the information of JNI and IRI 