### PR TITLE
perf: Optimize trits from trytes with x86 SIMD

### DIFF
--- a/src/trinary.c
+++ b/src/trinary.c
@@ -163,6 +163,9 @@ Trobject_t *trits_from_trytes(Trobject_t *trytes)
         return NULL;
     }
 
+#if defined(__SSE4_2__)
+    return trits_from_trytes_sse42(trytes);
+#endif
     Trobject_t *trits = NULL;
     int8_t *src = (int8_t *) malloc(trytes->len * 3);
 


### PR DESCRIPTION
Without SIMD optimization
Input size(byte) - Average time(nsec)
81               - 355.6
2592             - 5752.3
2673             - 6273.0

With SIMD optimization
Input size(byte) - Average time(nsec)
81               - 167.1
2592             - 1751.8
2673             - 2098.8

Hardware information
architecture - x86_64
CPU          - AMD Ryzen 5 2400G

Close #92.