### PR TITLE
test: Modify the difficulty and resource of testcases

### DIFF
--- a/tests/test-dcurl.c
+++ b/tests/test-dcurl.c
@@ -47,12 +47,12 @@ int main()
         "9999999999999999999999999999999999999999999999999999999999999999999999"
         "9999999999999";
 
-    int mwm = 9;
+    int mwm = 14;
 
     for (int loop_count = 0; loop_count < LOOP_MAX; loop_count++) {
-        /* test dcurl Implementation with mwm = 9 */
+        /* test dcurl Implementation with mwm = 14 */
         dcurl_init();
-        int8_t *ret_trytes = dcurl_entry((int8_t *) trytes, mwm, 0);
+        int8_t *ret_trytes = dcurl_entry((int8_t *) trytes, mwm, 8);
         assert(ret_trytes);
         dcurl_destroy();
 

--- a/tests/test-multi-pow.c
+++ b/tests/test-multi-pow.c
@@ -17,7 +17,7 @@ void *dcurl_entry_cb(void *arg)
     dcurl_item *item = (dcurl_item *) arg;
     /* test dcurl Implementation with mwm = 14 */
     int8_t *ret_trytes =
-        dcurl_entry(item->input_trytes, item->mwm, 0);
+        dcurl_entry(item->input_trytes, item->mwm, 8);
     assert(ret_trytes && "dcurl_entry() failed");
     memcpy(item->output_trytes, ret_trytes, TRANSACTION_TRYTES_LENGTH);
     free(ret_trytes);

--- a/tests/test-pow.c
+++ b/tests/test-pow.c
@@ -143,7 +143,7 @@ int main()
         /* test implementation with mwm = 14 */
         initializeImplContext(PoW_Context_ptr);
         void *pow_ctx =
-            getPoWContext(PoW_Context_ptr, (int8_t *) trytes, mwm, 0);
+            getPoWContext(PoW_Context_ptr, (int8_t *) trytes, mwm, 8);
         assert(pow_ctx);
 
         for (int count = 0; count < pow_total; count++) {


### PR DESCRIPTION
Change the mwm from 9(testnet) to 14(mainnet).
Use the fixed number of threads rather than the maximum available threads,
since the testcases are for validating the dcurl functionality,
not for exhausting the hardware resource.