### PR TITLE
fix: fix build error with BUILD_REMOTE and BUILD_JNI enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,11 @@ OBJS += \
 	remote_common.o \
 	remote_interface.o
 
-WORKER_OBJS := $(addprefix $(OUT)/worker-,$(filter-out remote_interface.o, $(OBJS)))
+WORKER_EXCLUDE_OBJS := remote_interface.o
+ifeq ("$(BUILD_JNI)", "1")
+WORKER_EXCLUDE_OBJS += jni/iri-pearldiver-exlib.o
+endif
+WORKER_OBJS := $(addprefix $(OUT)/worker-,$(filter-out $(WORKER_EXCLUDE_OBJS), $(OBJS)))
 WORKER_CFLAGS := $(filter-out -DENABLE_REMOTE, $(CFLAGS))
 endif
 


### PR DESCRIPTION
The JNI related object file is included in the remote worker related object files
if the build options BUILD_REMOTE and BUILD_JNI are enabled.
This should not happen and it causes the building error.
The commit make sure the un-related object files would not be included.

Close #166.