### PR TITLE
fix(build): Use RabbitMQ object files instead of shared library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,13 +170,13 @@ $(OUT)/%.o: $(SRC)/%.c $(LIBTUV_PATH)/include $(LIBRABBITMQ_PATH)/build/include
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) $(LIBTUV_INCLUDE) $(LIBRABBITMQ_INCLUDE) -c -MMD -MF $@.d $<
 
-$(OUT)/test-%: $(OUT)/test-%.o $(OBJS) $(LIBTUV_LIBRARY) $(LIBRABBITMQ_LIBRARY)
+$(OUT)/test-%: $(OUT)/test-%.o $(OBJS) $(LIBTUV_OBJS) $(LIBRABBITMQ_OBJS)
 	$(VECHO) "  LD\t$@\n"
-	$(Q)$(CC) -o $@ $^ $(LDFLAGS) $(LIBRABBITMQ_LINK)
+	$(Q)$(CC) -o $@ $^ $(LDFLAGS)
 
-$(OUT)/libdcurl.so: $(OBJS) $(LIBTUV_LIBRARY) $(LIBRABBITMQ_LIBRARY)
+$(OUT)/libdcurl.so: $(OBJS) $(LIBTUV_OBJS) $(LIBRABBITMQ_OBJS)
 	$(VECHO) "  LD\t$@\n"
-	$(Q)$(CC) -shared -o $@ $^ $(LDFLAGS) $(LIBRABBITMQ_LINK)
+	$(Q)$(CC) -shared -o $@ $^ $(LDFLAGS)
 
 ifeq ("$(BUILD_REMOTE)", "1")
 include mk/remote.mk

--- a/mk/remote.mk
+++ b/mk/remote.mk
@@ -3,6 +3,6 @@ $(OUT)/worker-%.o: $(SRC)/%.c $(LIBTUV_PATH)/include $(LIBRABBITMQ_PATH)/build/i
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(WORKER_CFLAGS) $(LIBTUV_INCLUDE) $(LIBRABBITMQ_INCLUDE) -c -MMD -MF $@.d $<
 
-$(OUT)/remote-worker: $(OUT)/remote_worker.o $(WORKER_OBJS) $(LIBTUV_LIBRARY) $(LIBRABBITMQ_LIBRARY)
+$(OUT)/remote-worker: $(OUT)/remote_worker.o $(WORKER_OBJS) $(LIBTUV_OBJS) $(LIBRABBITMQ_OBJS)
 	$(VECHO) "  LD\t$@\n"
-	$(Q)$(CC) -o $@ $^ $(LDFLAGS) $(LIBRABBITMQ_LINK)
+	$(Q)$(CC) -o $@ $^ $(LDFLAGS)

--- a/mk/submodule.mk
+++ b/mk/submodule.mk
@@ -31,6 +31,10 @@ $(LIBTUV_OBJS):
 LIBRABBITMQ_PATH = deps/rabbitmq-c
 LIBRABBITMQ_INCLUDE := -I $(LIBRABBITMQ_PATH)/build/include
 LIBRABBITMQ_OBJS := $(LIBRABBITMQ_PATH)/build/librabbitmq/CMakeFiles/rabbitmq.dir/*.o
+ifeq ($(UNAME_S),darwin)
+    OPENSSL_PATH := /usr/local/opt/openssl
+    LDFLAGS += -L$(OPENSSL_PATH)/lib -lcrypto -lssl
+endif
 
 $(LIBRABBITMQ_PATH)/build/include:
 	git submodule update --init $(LIBRABBITMQ_PATH)
@@ -38,7 +42,7 @@ $(LIBRABBITMQ_PATH)/build/include:
 ifeq ($(UNAME_S),darwin)
 	# macOS
 	cd $(LIBRABBITMQ_PATH)/build && \
-         cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/ -DCMAKE_INSTALL_PREFIX=. .. && \
+         cmake -DOPENSSL_ROOT_DIR=$(OPENSSL_PATH) -DCMAKE_INSTALL_PREFIX=. .. && \
          cmake --build . --target install
 else
 	cd $(LIBRABBITMQ_PATH)/build && \

--- a/mk/submodule.mk
+++ b/mk/submodule.mk
@@ -18,27 +18,19 @@ LIBTUV_PATH = deps/libtuv
 LIBTUV_INCLUDE := -I $(LIBTUV_PATH)/include
 LIBTUV_PLATFORM := $(UNAME_M)-$(UNAME_S)
 LIBTUV_BOARD := $(BOARD)
-# PIC (Position-Independent-Code) library
-LIBTUV_LIBRARY := $(LIBTUV_PATH)/build/$(LIBTUV_PLATFORM)/release/lib/libtuv.o
+# PIC (Position-Independent-Code) object file
+LIBTUV_OBJS := $(LIBTUV_PATH)/build/$(LIBTUV_PLATFORM)/release/lib/libtuv.o
 
 $(LIBTUV_PATH)/include:
 	git submodule update --init $(LIBTUV_PATH)
 
-$(LIBTUV_LIBRARY):
+$(LIBTUV_OBJS):
 	$(MAKE) -C $(LIBTUV_PATH) TUV_BUILD_TYPE=release TUV_CREATE_PIC_LIB=yes TUV_PLATFORM=$(LIBTUV_PLATFORM) TUV_BOARD=$(LIBTUV_BOARD)
 
 # librabbitmq related variables
 LIBRABBITMQ_PATH = deps/rabbitmq-c
 LIBRABBITMQ_INCLUDE := -I $(LIBRABBITMQ_PATH)/build/include
-LIBRABBITMQ_LIB_PATH := $(LIBRABBITMQ_PATH)/build/librabbitmq/
-ifeq ($(UNAME_S),darwin)
-    # macOS
-    LIBRABBITMQ_LINK := -Wl,-rpath,$(LIBRABBITMQ_LIB_PATH) -L$(LIBRABBITMQ_LIB_PATH) -lrabbitmq
-    LIBRABBITMQ_LIBRARY := $(LIBRABBITMQ_LIB_PATH)/librabbitmq.dylib
-else
-    LIBRABBITMQ_LINK := -Wl,-rpath=$(LIBRABBITMQ_LIB_PATH) -L$(LIBRABBITMQ_LIB_PATH) -lrabbitmq
-    LIBRABBITMQ_LIBRARY := $(LIBRABBITMQ_LIB_PATH)/librabbitmq.so
-endif
+LIBRABBITMQ_OBJS := $(LIBRABBITMQ_PATH)/build/librabbitmq/CMakeFiles/rabbitmq.dir/*.o
 
 $(LIBRABBITMQ_PATH)/build/include:
 	git submodule update --init $(LIBRABBITMQ_PATH)
@@ -54,6 +46,6 @@ else
          cmake --build . --target install
 endif
 
-$(LIBRABBITMQ_LIBRARY):
+$(LIBRABBITMQ_OBJS):
 	cd $(LIBRABBITMQ_PATH)/build && \
          cmake --build .


### PR DESCRIPTION
The final generated libdcurl.so should be able
to use the submodule projects directly without any dynamic linking.
Otherwise, the integration with IRI would fail.

Since dcurl builds with the object files of the submodule projects,
the variable naming is changed from _LIBRARY to _OBJS.

Close #152.