### PR TITLE
build: Exclude RabbitMQ when BUILD_REMOTE is off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ LIBS := $(addprefix $(OUT)/, $(LIBS))
 JARS := dcurljni-$(VERSION).jar
 JARS := $(addprefix $(OUT)/, $(JARS))
 
-PREQ := config $(TESTS) $(LIBS)
+PREQ := $(SUBS) config $(TESTS) $(LIBS)
 ifeq ("$(BUILD_JNI)","1")
 PREQ += $(JARS)
 endif
@@ -162,19 +162,19 @@ endif
 
 OBJS := $(addprefix $(OUT)/, $(OBJS))
 
-$(OUT)/test-%.o: tests/test-%.c $(LIBTUV_PATH)/include
+$(OUT)/test-%.o: tests/test-%.c
 	$(VECHO) "  CC\t$@\n"
-	$(Q)$(CC) -o $@ $(CFLAGS) -I $(SRC) $(LIBTUV_INCLUDE) -c -MMD -MF $@.d $<
+	$(Q)$(CC) -o $@ $(CFLAGS) -I $(SRC) $(SUB_INCLUDE) -c -MMD -MF $@.d $<
 
-$(OUT)/%.o: $(SRC)/%.c $(LIBTUV_PATH)/include $(LIBRABBITMQ_PATH)/build/include
+$(OUT)/%.o: $(SRC)/%.c $(SUB_OBJS)
 	$(VECHO) "  CC\t$@\n"
-	$(Q)$(CC) -o $@ $(CFLAGS) $(LIBTUV_INCLUDE) $(LIBRABBITMQ_INCLUDE) -c -MMD -MF $@.d $<
+	$(Q)$(CC) -o $@ $(CFLAGS) $(SUB_INCLUDE) -c -MMD -MF $@.d $<
 
-$(OUT)/test-%: $(OUT)/test-%.o $(OBJS) $(LIBTUV_OBJS) $(LIBRABBITMQ_OBJS)
+$(OUT)/test-%: $(OUT)/test-%.o $(OBJS) $(SUB_OBJS)
 	$(VECHO) "  LD\t$@\n"
 	$(Q)$(CC) -o $@ $^ $(LDFLAGS)
 
-$(OUT)/libdcurl.so: $(OBJS) $(LIBTUV_OBJS) $(LIBRABBITMQ_OBJS)
+$(OUT)/libdcurl.so: $(OBJS) $(SUB_OBJS)
 	$(VECHO) "  LD\t$@\n"
 	$(Q)$(CC) -shared -o $@ $^ $(LDFLAGS)
 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -26,7 +26,7 @@ NO_COLOR = \e[0m
 $(OUT)/test-%.done: $(OUT)/test-%
 	$(Q)$(PRINTF) "*** Validating $< ***\n"
 	$(Q)./$< && $(PRINTF) "\t$(PASS_COLOR)[ Verified ]$(NO_COLOR)\n"
-check: $(addsuffix .done, $(TESTS))
+check: $(SUBS) $(addsuffix .done, $(TESTS))
 
 config: $(OUT)/config-timestamp
 

--- a/mk/remote.mk
+++ b/mk/remote.mk
@@ -1,8 +1,8 @@
 # Build remote-worker
-$(OUT)/worker-%.o: $(SRC)/%.c $(LIBTUV_PATH)/include $(LIBRABBITMQ_PATH)/build/include
+$(OUT)/worker-%.o: $(SRC)/%.c
 	$(VECHO) "  CC\t$@\n"
-	$(Q)$(CC) -o $@ $(WORKER_CFLAGS) $(LIBTUV_INCLUDE) $(LIBRABBITMQ_INCLUDE) -c -MMD -MF $@.d $<
+	$(Q)$(CC) -o $@ $(WORKER_CFLAGS) $(SUB_INCLUDE) -c -MMD -MF $@.d $<
 
-$(OUT)/remote-worker: $(OUT)/remote_worker.o $(WORKER_OBJS) $(LIBTUV_OBJS) $(LIBRABBITMQ_OBJS)
+$(OUT)/remote-worker: $(OUT)/remote_worker.o $(WORKER_OBJS) $(SUB_OBJS)
 	$(VECHO) "  LD\t$@\n"
 	$(Q)$(CC) -o $@ $^ $(LDFLAGS)

--- a/mk/submodule.mk
+++ b/mk/submodule.mk
@@ -36,9 +36,11 @@ ifeq ($(UNAME_S),darwin)
     LDFLAGS += -L$(OPENSSL_PATH)/lib -lcrypto -lssl
 endif
 
-$(LIBRABBITMQ_PATH)/build/include:
+$(LIBRABBITMQ_PATH)/librabbitmq:
 	git submodule update --init $(LIBRABBITMQ_PATH)
-	mkdir $(LIBRABBITMQ_PATH)/build
+
+$(LIBRABBITMQ_OBJS):
+	mkdir -p $(LIBRABBITMQ_PATH)/build
 ifeq ($(UNAME_S),darwin)
 	# macOS
 	cd $(LIBRABBITMQ_PATH)/build && \
@@ -49,7 +51,21 @@ else
          cmake -DCMAKE_INSTALL_PREFIX=. .. && \
          cmake --build . --target install
 endif
-
-$(LIBRABBITMQ_OBJS):
 	cd $(LIBRABBITMQ_PATH)/build && \
          cmake --build .
+
+# Submodules
+SUBS := $(LIBTUV_PATH)/include
+ifeq ($(BUILD_REMOTE),1)
+    SUBS += $(LIBRABBITMQ_PATH)/librabbitmq
+endif
+# Submodule related objects
+SUB_OBJS := $(LIBTUV_OBJS)
+ifeq ($(BUILD_REMOTE),1)
+    SUB_OBJS += $(LIBRABBITMQ_OBJS)
+endif
+# Submodule C flags for including header files
+SUB_INCLUDE := $(LIBTUV_INCLUDE)
+ifeq ($(BUILD_REMOTE),1)
+    SUB_INCLUDE += $(LIBRABBITMQ_INCLUDE)
+endif


### PR DESCRIPTION
When the build option BUILD_REMOTE is off, the RabbitMQ should not be
compiled and included in the generated files.
Makefile modification:
- Extract the steps of submodule initialization and update
- Combine and create the submodule related variables

Close #169.