### PR TITLE
build: Add de10-nano board specific compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ include mk/cpu-features.mk
 # Handle git submodule
 include mk/submodule.mk
 
+# Board specific compiler flags
+include mk/board.mk
+
 # Assign the hardware to CPU if no hardware is specified
 PLATFORMS := $(BUILD_AVX) $(BUILD_SSE) $(BUILD_GENERIC) $(BUILD_GPU) $(BUILD_FPGA_ACCEL)
 ENABLE_PLATFORMS := $(findstring 1,$(PLATFORMS))

--- a/mk/board.mk
+++ b/mk/board.mk
@@ -1,0 +1,3 @@
+ifeq ($(BOARD),de10nano)
+    CFLAGS += -mcpu=cortex-a9 -mtune=cortex-a9 -mfloat-abi=hard -mfpu=neon
+endif


### PR DESCRIPTION
-mcpu=cortex-a9:
The CPU of de10-nano board is Cortex-A9.
-mfloat-abi=softfp:
The NEON intrinsics are not available with the soft option.
Use softfp instead of soft.
-mfpu=neon:
neon equals to neon-vfpv3.