### PR TITLE
CI: add new version release workflow

### DIFF
--- a/.auto-changelog
+++ b/.auto-changelog
@@ -1,0 +1,4 @@
+{
+  "template": "changelog.hbs",
+  "issuePattern": "fix.*:"
+}

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "before:github:release": [
+      "make BUILD_REMOTE=1 BUILD_DEBUG=1 BOARD=de10nano BUILD_FPGA_ACCEL=1",
+      "tar zcvf remote-worker.tar.gz --directory=build remote-worker"
+    ]
+  },
+  "git": {
+    "changelog": "npx auto-changelog --stdout",
+    "requireUpstream": false,
+    "commit": false,
+    "tag": true,
+    "tagName": "v${version}",
+    "push": false
+  },
+  "github": {
+    "release": true,
+    "releaseName": "v${version}",
+    "preRelease": true,
+    "draft": true,
+    "tokenRef": "GITHUB_TOKEN",
+    "assets": [
+      "remote-worker.tar.gz"
+    ]
+  }
+}

--- a/changelog.hbs
+++ b/changelog.hbs
@@ -1,0 +1,19 @@
+{{#with releases.[0]}}
+
+  ## {{title}} {{#if niceDate}}({{niceDate}}){{/if}}
+
+  ### :tada: New Features
+
+  {{#commit-list merges heading="" message='feat.*: '}}
+    - {{{message}}} ({{commit.shorthash}})
+  {{/commit-list}}
+
+  {{#commit-list commits heading="" message='feat.*: '}}
+    - {{{subject}}} ({{shorthash}})
+  {{/commit-list}}
+
+  {{#commit-list fixes heading='### :bug: Bug Fixes'}}
+    - {{commit.subject}} ({{commit.shorthash}})
+  {{/commit-list}}
+
+{{/with}}

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,20 @@
+# Release Workflow
+
+The motivation of release workfow is to update the GitHub release page
+when there is a new tag pushed to the GitHub.
+
+The release workflow uses `auto-changelog` utility to generate the
+changelog, then use `release-it` utility to publish the changelog
+on the release page.
+
+The `release-it` will also build the `remote-worker`, and upload the
+packed the `remote-worker` to release page.
+
+- `.release-it`: `release-it` configuration file
+- `.auto-changelog`: `auto-changelog` configuration file
+- `changelog.hbs`: changelog template file
+
+## Reference
+
+- [release-it/release-it](https://github.com/release-it/release-it)
+- [CookPete/auto-changelog](https://github.com/CookPete/auto-changelog)


### PR DESCRIPTION
Add workflow to release a new version on GitHub release page, and it
will be trigger when tag push to the GitHub.

This workflow uses "auto-changelog" utility to generate the changelog,
then use "release-it" utility to publish the changelog on the release
page.

The "release-it" will also build the "remote-worker", and upload the
packed the "remote-worker" to release page.

 - .release-it: "release-it" configuration file
 - .auto-changelog: "auto-changelog" configuration file
 - changelog.hbs: changelog template file

See also:
 - https://github.com/release-it/release-it
 - https://github.com/CookPete/auto-changelog