### PR TITLE
refactor: Change log function for unification with entangled

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -20,7 +20,13 @@
 
 double diff_in_second(struct timespec t1, struct timespec t2);
 
-static inline void ddprintf(const char *format, ...)
+/* Copy from logger project:
+ * https://bitbucket.org/embear/logger/src/abef6b0a6c991545a3d3fecfbc39d2b0448fb85a/include/logger.h#lines-199*/
+typedef int16_t logger_id_t;
+
+static inline void log_debug(logger_id_t const logger_id,
+                             const char *format,
+                             ...)
 {
 #if defined(ENABLE_DEBUG)
     va_list ap;
@@ -29,6 +35,17 @@ static inline void ddprintf(const char *format, ...)
     va_end(ap);
     fflush(stdout);
 #endif
+}
+
+static inline void log_info(logger_id_t const logger_id,
+                             const char *format,
+                             ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vprintf(format, ap);
+    va_end(ap);
+    fflush(stdout);
 }
 
 typedef struct _pow_info PoW_Info;

--- a/src/implcontext.c
+++ b/src/implcontext.c
@@ -23,8 +23,9 @@ bool initializeImplContext(ImplContext *impl_ctx)
 {
     bool res = impl_ctx->initialize(impl_ctx);
     if (res) {
-        ddprintf(MSG_PREFIX "Implementation %s is initialized successfully\n",
-                 impl_ctx->description);
+        log_debug(0,
+                  MSG_PREFIX "Implementation %s is initialized successfully\n",
+                  impl_ctx->description);
     }
     return res;
 }

--- a/src/remote_common.c
+++ b/src/remote_common.c
@@ -19,11 +19,11 @@ bool die_on_amqp_error(amqp_rpc_reply_t x, char const *context)
         return true;
 
     case AMQP_RESPONSE_NONE:
-        ddprintf("%s: missing RPC reply type!\n", context);
+        log_debug(0, "%s: missing RPC reply type!\n", context);
         break;
 
     case AMQP_RESPONSE_LIBRARY_EXCEPTION:
-        ddprintf("%s: %s\n", context, amqp_error_string2(x.library_error));
+        log_debug(0, "%s: %s\n", context, amqp_error_string2(x.library_error));
         break;
 
     case AMQP_RESPONSE_SERVER_EXCEPTION:
@@ -31,21 +31,21 @@ bool die_on_amqp_error(amqp_rpc_reply_t x, char const *context)
         case AMQP_CONNECTION_CLOSE_METHOD: {
             amqp_connection_close_t *m =
                 (amqp_connection_close_t *) x.reply.decoded;
-            ddprintf("%s: server connection error %u, message: %.*s\n",
-                     context, m->reply_code, (int) m->reply_text.len,
-                     (char *) m->reply_text.bytes);
+            log_debug(0, "%s: server connection error %u, message: %.*s\n",
+                      context, m->reply_code, (int) m->reply_text.len,
+                      (char *) m->reply_text.bytes);
             break;
         }
         case AMQP_CHANNEL_CLOSE_METHOD: {
             amqp_channel_close_t *m = (amqp_channel_close_t *) x.reply.decoded;
-            ddprintf("%s: server channel error %u, message: %.*s\n", context,
-                     m->reply_code, (int) m->reply_text.len,
-                     (char *) m->reply_text.bytes);
+            log_debug(0, "%s: server channel error %u, message: %.*s\n",
+                      context, m->reply_code, (int) m->reply_text.len,
+                      (char *) m->reply_text.bytes);
             break;
         }
         default:
-            ddprintf("%s: unknown server error, method id 0x%08X\n", context,
-                     x.reply.id);
+            log_debug(0, "%s: unknown server error, method id 0x%08X\n",
+                      context, x.reply.id);
             break;
         }
         break;
@@ -57,7 +57,7 @@ bool die_on_amqp_error(amqp_rpc_reply_t x, char const *context)
 bool die_on_error(int x, char const *context)
 {
     if (x < 0) {
-        ddprintf("%s: %s\n", context, amqp_error_string2(x));
+        log_debug(0, "%s: %s\n", context, amqp_error_string2(x));
         return false;
     }
 
@@ -73,7 +73,7 @@ bool connect_broker(amqp_connection_state_t *conn, const char *hostName)
     *conn = amqp_new_connection();
     socket = amqp_tcp_socket_new(*conn);
     if (amqp_socket_open(socket, host, 5672) != AMQP_STATUS_OK) {
-        ddprintf("The rabbitmq broker of %s is closed\n", host);
+        log_debug(0, "The rabbitmq broker of %s is closed\n", host);
         goto destroy_connection;
     }
 
@@ -197,24 +197,25 @@ bool wait_response_message(amqp_connection_state_t *conn,
         if (!die_on_amqp_error(amqp_get_rpc_reply(*conn), "Wait method frame"))
             return false;
 
-        ddprintf(MSG_PREFIX "Frame type: %u channel: %u\n", frame.frame_type,
-                 frame.channel);
+        log_debug(0, MSG_PREFIX "Frame type: %u channel: %u\n",
+                  frame.frame_type, frame.channel);
 
         if (frame.frame_type != AMQP_FRAME_METHOD)
             continue;
 
-        ddprintf(MSG_PREFIX "Method: %s\n",
-                 amqp_method_name(frame.payload.method.id));
+        log_debug(0, MSG_PREFIX "Method: %s\n",
+                  amqp_method_name(frame.payload.method.id));
 
         if (frame.payload.method.id != AMQP_BASIC_DELIVER_METHOD)
             continue;
 
 #if defined(ENABLE_DEBUG)
         d = (amqp_basic_deliver_t *) frame.payload.method.decoded;
-        ddprintf(MSG_PREFIX "Delivery: %u exchange: %.*s routingkey: %.*s\n",
-                 (unsigned) d->delivery_tag, (int) d->exchange.len,
-                 (char *) d->exchange.bytes, (int) d->routing_key.len,
-                 (char *) d->routing_key.bytes);
+        log_debug(0,
+                  MSG_PREFIX "Delivery: %u exchange: %.*s routingkey: %.*s\n",
+                  (unsigned) d->delivery_tag, (int) d->exchange.len,
+                  (char *) d->exchange.bytes, (int) d->routing_key.len,
+                  (char *) d->routing_key.bytes);
 #endif
 
         amqp_maybe_release_buffers(*conn);
@@ -227,18 +228,19 @@ bool wait_response_message(amqp_connection_state_t *conn,
             return false;
 
         if (frame.frame_type != AMQP_FRAME_HEADER) {
-            ddprintf("Unexpected header!\n");
+            log_debug(0, "Unexpected header!\n");
             return false;
         }
 
 #if defined(ENABLE_DEBUG)
         p = (amqp_basic_properties_t *) frame.payload.properties.decoded;
         if (p->_flags & AMQP_BASIC_CONTENT_TYPE_FLAG) {
-            ddprintf(MSG_PREFIX "Content-type: %.*s\n",
-                     (int) p->content_type.len, (char *) p->content_type.bytes);
+            log_debug(0, MSG_PREFIX "Content-type: %.*s\n",
+                      (int) p->content_type.len,
+                      (char *) p->content_type.bytes);
         }
 #endif
-        ddprintf("---\n");
+        log_debug(0, "---\n");
 
         body_target = (size_t) frame.payload.properties.body_size;
         body_received = 0;
@@ -252,24 +254,24 @@ bool wait_response_message(amqp_connection_state_t *conn,
                 return false;
 
             if (frame.frame_type != AMQP_FRAME_BODY) {
-                ddprintf("Unexpected body\n");
+                log_debug(0, "Unexpected body\n");
                 return false;
             }
 
             body_received += frame.payload.body_fragment.len;
         }
         if (body_received != body_target) {
-            ddprintf("Received body is smaller than body target\n");
+            log_debug(0, "Received body is smaller than body target\n");
             return false;
         }
 
         memcpy(frame_body, (char *) frame.payload.body_fragment.bytes,
                body_len);
 
-        ddprintf(MSG_PREFIX "PoW result: %.*s\n",
-                 (int) frame.payload.body_fragment.len,
-                 (char *) frame.payload.body_fragment.bytes);
-        ddprintf("---\n");
+        log_debug(0, MSG_PREFIX "PoW result: %.*s\n",
+                  (int) frame.payload.body_fragment.len,
+                  (char *) frame.payload.body_fragment.bytes);
+        log_debug(0, "---\n");
 
         /* everything was fine, we can quit now because we received the reply */
         return true;
@@ -315,7 +317,8 @@ bool publish_message_with_reply_to(amqp_connection_state_t *conn,
                       "Publishing the message with reply_to"))
         return false;
 
-    ddprintf(MSG_PREFIX "callback queue %s \n", (char *) props.reply_to.bytes);
+    log_debug(0, MSG_PREFIX "callback queue %s \n",
+              (char *) props.reply_to.bytes);
     amqp_bytes_free(props.reply_to);
 
     return true;

--- a/src/remote_interface.c
+++ b/src/remote_interface.c
@@ -14,8 +14,9 @@ bool initializeRemoteContext(RemoteImplContext *remote_ctx)
 {
     bool res = remote_ctx->initialize(remote_ctx);
     if (res) {
-        ddprintf(MSG_PREFIX "Implementation %s is initialized successfully\n",
-                 remote_ctx->description);
+        log_debug(0,
+                  MSG_PREFIX "Implementation %s is initialized successfully\n",
+                  remote_ctx->description);
     }
     return res;
 }
@@ -68,20 +69,20 @@ bool PoWValidation(int8_t *output_trytes, int mwm)
 {
     Trytes_t *trytes_t = initTrytes(output_trytes, TRANSACTION_TRYTES_LENGTH);
     if (!trytes_t) {
-        ddprintf("PoW Validation: Initialization of Trytes fails\n");
+        log_debug(0, "PoW Validation: Initialization of Trytes fails\n");
         goto fail_to_inittrytes;
     }
 
     Trytes_t *hash_trytes = hashTrytes(trytes_t);
     if (!hash_trytes) {
-        ddprintf("PoW Validation: Hashing trytes fails\n");
+        log_debug(0, "PoW Validation: Hashing trytes fails\n");
         goto fail_to_hashtrytes;
     }
 
     Trits_t *ret_trits = trits_from_trytes(hash_trytes);
     for (int i = 243 - 1; i >= 243 - mwm; i--) {
         if (ret_trits->data[i] != 0) {
-            ddprintf("PoW Validation fails\n");
+            log_debug(0, "PoW Validation fails\n");
             goto fail_to_validation;
         }
     }

--- a/src/remote_worker.c
+++ b/src/remote_worker.c
@@ -54,7 +54,8 @@ int main(int argc, char *const *argv)
         if (!consume_message(&conn, 1, &envelope))
             goto fail;
 
-        ddprintf(
+        log_debug(
+            0,
             MSG_PREFIX
             "Delivery %u, exchange %.*s, routingkey %.*s, callback queue: %s "
             "\n",
@@ -63,9 +64,9 @@ int main(int argc, char *const *argv)
             (char *) envelope.routing_key.bytes,
             (char *) envelope.message.properties.reply_to.bytes);
         if (envelope.message.properties._flags & AMQP_BASIC_CONTENT_TYPE_FLAG) {
-            ddprintf(MSG_PREFIX "Content-type: %.*s\n",
-                     (int) envelope.message.properties.content_type.len,
-                     (char *) envelope.message.properties.content_type.bytes);
+            log_debug(0, MSG_PREFIX "Content-type: %.*s\n",
+                      (int) envelope.message.properties.content_type.len,
+                      (char *) envelope.message.properties.content_type.bytes);
         }
 
         /* Message body format: transacton | mwm */
@@ -73,15 +74,15 @@ int main(int argc, char *const *argv)
         memcpy(buf, envelope.message.body.bytes + TRANSACTION_TRYTES_LENGTH, 4);
         mwm = strtol(buf, NULL, 10);
 
-        ddprintf(MSG_PREFIX "Doing PoW with mwm = %d...\n", mwm);
+        log_debug(0, MSG_PREFIX "Doing PoW with mwm = %d...\n", mwm);
 
         int8_t *ret_trytes = dcurl_entry((int8_t *) trytes, mwm, 0);
         memset(buf, '0', sizeof(buf));
-        ddprintf(MSG_PREFIX "PoW is done\n");
+        log_debug(0, MSG_PREFIX "PoW is done\n");
 
         if (!acknowledge_broker(&conn, 1, &envelope))
             goto fail;
-        ddprintf(MSG_PREFIX "Sending an ack is done\n");
+        log_debug(0, MSG_PREFIX "Sending an ack is done\n");
 
         /* Publish a message of remote PoW result */
         if (!publish_message(
@@ -91,9 +92,9 @@ int main(int argc, char *const *argv)
 
         free(ret_trytes);
         amqp_destroy_envelope(&envelope);
-        ddprintf(MSG_PREFIX
-                 "Publishing PoW result to callback queue is done\n");
-        ddprintf(MSG_PREFIX "---\n");
+        log_debug(
+            0, MSG_PREFIX "Publishing PoW result to callback queue is done\n");
+        log_debug(0, MSG_PREFIX "---\n");
     }
 
 fail:

--- a/tests/test-pow.c
+++ b/tests/test-pow.c
@@ -144,7 +144,7 @@ int main()
 
     for (int idx = 0; idx < sizeof(ImplContextArr) / sizeof(ImplContext);
          idx++) {
-        printf("%s\n", description[idx]);
+        log_info(0, "%s\n", description[idx]);
 
         ImplContext *PoW_Context_ptr = &ImplContextArr[idx];
 
@@ -189,16 +189,17 @@ int main()
         freePoWContext(PoW_Context_ptr, pow_ctx);
         destroyImplContext(PoW_Context_ptr);
 
-        printf("PoW execution times: %d times.\n", pow_total);
+        log_info(0, "PoW execution times: %d times.\n", pow_total);
 #if defined(ENABLE_STAT)
-        printf("Hash rate average value: %.3lf kH/sec,\n",
-               getAvg(hashRateArr, pow_total) / 1000);
-        printf(
+        log_info(0, "Hash rate average value: %.3lf kH/sec,\n",
+                 getAvg(hashRateArr, pow_total) / 1000);
+        log_info(
+            0,
             "with the range +- %.3lf kH/sec including 95%% of the hash rate "
             "values.\n",
             2 * getStdDeviation(hashRateArr, pow_total) / 1000);
 #endif
-        printf("Success.\n");
+        log_info(0, "Success.\n");
     }
 
     return 0;


### PR DESCRIPTION
The original ddprintf() function name is changed to the similar function
log_debug() in entangled.
The implementation is unchanged since the dcurl does not integrate with
the logger project used by entangled.
Currently dcurl has its own implementation.

For unification, the logger_id_t logger_id parameter of log_debug() is added
and assigned with 0.

And there is a new log function log_info() for release mode.

Close #180.