### PR TITLE
fix: Avoid queue missing error

### DIFF
--- a/src/remote_worker.c
+++ b/src/remote_worker.c
@@ -47,6 +47,9 @@ int main(int argc, char *const *argv)
     if (!connect_broker(&conn, hostIP))
         goto fail;
 
+    if (!declare_queue(&conn, 1, "incoming_queue"))
+        goto fail;
+
     if (!set_consuming_queue(&conn, 1, "incoming_queue"))
         goto fail;
 


### PR DESCRIPTION
Declare queue in the remote worker source code to avoid queue missing
error when the new RabbitMQ broker is created and the remote worker
is activated right after it.

Close #209.