### PR TITLE
CI: Suppress CppCheck warning with --inline-suppr option

### DIFF
--- a/cppcheck_suppress
+++ b/cppcheck_suppress
@@ -1,15 +1,2 @@
-// The most significant bit is not used as a signed bit
-shiftTooManyBitsSigned:src/pow_avx.c:321
-
-// The unused functions are for the ccurl compatibility
-unusedFunction:src/compat_ccurl.c:18
-unusedFunction:src/compat_ccurl.c:29
-unusedFunction:src/compat_ccurl.c:34
-
-// The invoked functions of OpenCL are not checked correctly with CppCheck
-unusedFunction:src/pow_kernel.cl:213
-unusedFunction:src/pow_kernel.cl:248
-unusedFunction:src/pow_kernel.cl:284
-
 // Do not treat system header files missing as errors
 missingIncludeSystem:*

--- a/mk/static-analysis.mk
+++ b/mk/static-analysis.mk
@@ -18,6 +18,7 @@ static-analysis:
 	  --enable=all \
 	  --error-exitcode=1 \
 	  --force \
+	  --inline-suppr \
 	  -I $(SRC) \
 	  $(LIBTUV_INCLUDE) \
 	  $(LIBRABBITMQ_INCLUDE) \

--- a/src/compat_ccurl.c
+++ b/src/compat_ccurl.c
@@ -15,6 +15,7 @@ static bool is_initialized = false;
 /* mutex protecting initialization section */
 static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
 
+// cppcheck-suppress unusedFunction ; The unused functions are for the ccurl compatibility
 char *ccurl_pow(char *trytes, int mwm)
 {
     pthread_mutex_lock(&mtx);
@@ -26,11 +27,13 @@ char *ccurl_pow(char *trytes, int mwm)
     return (char *) dcurl_entry((int8_t *) trytes, mwm, 1);
 }
 
+// cppcheck-suppress unusedFunction ; The unused functions are for the ccurl compatibility
 void ccurl_pow_finalize(void)
 {
     dcurl_destroy();
 }
 
+// cppcheck-suppress unusedFunction ; The unused functions are for the ccurl compatibility
 void ccurl_pow_interrupt(void)
 {
     /* Do Nothing */

--- a/src/pow_avx.c
+++ b/src/pow_avx.c
@@ -318,6 +318,7 @@ static int check_256(__m256d *l, __m256d *h, int m)
     for (j = 0; j < 4; j++) {
         for (i = 0; i < 64; i++) {
             long long np = ((dl) nonce_probe[j]).l;
+            // cppcheck-suppress shiftTooManyBitsSigned ; The most significant bit is not used as a signed bit
             if ((np >> i) & 1) {
                 return i + j * 64;
             }

--- a/src/pow_kernel.cl
+++ b/src/pow_kernel.cl
@@ -210,6 +210,7 @@ void setup_ids(__private size_t *id,
     *n_trits -= (*n_trits) * (*id) < STATE_TRITS_LENGTH ? 0 : 1;
 }
 
+// cppcheck-suppress unusedFunction ; The invoked functions of OpenCL are not checked correctly with CppCheck
 __kernel void init(__global char *trit_hash,
                    __global bc_trit_t *mid_low,
                    __global bc_trit_t *mid_high,
@@ -245,6 +246,7 @@ __kernel void init(__global char *trit_hash,
     }
 }
 
+// cppcheck-suppress unusedFunction ; The invoked functions of OpenCL are not checked correctly with CppCheck
 __kernel void search(__global char *trit_hash,
                      __global bc_trit_t *mid_low,
                      __global bc_trit_t *mid_high,
@@ -281,6 +283,7 @@ __kernel void search(__global char *trit_hash,
     }
 }
 
+// cppcheck-suppress unusedFunction ; The invoked functions of OpenCL are not checked correctly with CppCheck
 __kernel void finalize(__global char *trit_hash,
                        __global bc_trit_t *mid_low,
                        __global bc_trit_t *mid_high,


### PR DESCRIPTION
Use the CppCheck --inline-suppr option to suppress the detected
warnings by adding the corresponding comment in the source code.
The previous method needs to specify the source code line number
in the suppression file, which is less flexible to maintain.

Close #215.