### PR TITLE
feat: Change dcurl_init API to enable initialization configuration

### DIFF
--- a/src/dcurl.c
+++ b/src/dcurl.c
@@ -71,7 +71,7 @@ extern remote_impl_context_t remote_context;
 static uv_sem_t notify_remote;
 #endif
 
-bool dcurl_init()
+bool dcurl_init(dcurl_config *config)
 {
     bool ret = false;
 
@@ -107,6 +107,11 @@ bool dcurl_init()
 #endif
 
 #if defined(ENABLE_REMOTE)
+    if (!config) {
+        remote_context.broker_host = DEFAULT_BROKER_HOST;
+    } else {
+        remote_context.broker_host = config->broker_host;
+    }
     if (register_remote_context(&remote_context)) {
         runtime_caps |= CAP_REMOTE;
         ret |= true;

--- a/src/dcurl.h
+++ b/src/dcurl.h
@@ -23,16 +23,32 @@
  * easily.
  */
 
+/*! The default value of the broker hostname */
+#define DEFAULT_BROKER_HOST "localhost"
+
+/**
+ * A structure representing the configuration of the initialization.
+ */
+typedef struct {
+    char *broker_host; /**< The broker hostname used in the remote mode */
+} dcurl_config;
+
 /**
  * @brief dcurl initialization.
  *
  * Register the determined hardware into the list and initialize the
  * corresponding resource.
+ * @param [in] config
+ * @parblock
+ * The configuration of the initialization.
+ *
+ * NULL: Use default configuration.
+ * @endparblock
  * @return
  * - true: one of the initialization succeeded.
  * - false: all the initialization failed.
  */
-bool dcurl_init();
+bool dcurl_init(dcurl_config *config);
 
 /**
  * @brief dcurl destruction.

--- a/src/remote_interface.c
+++ b/src/remote_interface.c
@@ -159,7 +159,7 @@ static bool remote_init(remote_impl_context_t *remote_ctx)
     memset(remote_ctx->slots, 0, remote_ctx->num_max_thread * sizeof(bool));
 
     for (int i = 0; i < CONN_MAX; i++) {
-        if (!connect_broker(&remote_ctx->conn[i], NULL))
+        if (!connect_broker(&remote_ctx->conn[i], remote_ctx->broker_host))
             goto fail_to_init;
     }
     if (!declare_queue(&remote_ctx->conn[0], 1, "incoming_queue"))

--- a/src/remote_interface.h
+++ b/src/remote_interface.h
@@ -44,6 +44,8 @@ struct remote_impl_context_s {
                                               available */
     int num_max_thread;
     int num_working_thread;
+    /* RabbitMQ broker hostname */
+    char *broker_host;
 
     /* Functions of Implementation Context */
     bool (*initialize)(remote_impl_context_t *remote_ctx);

--- a/src/remote_worker.c
+++ b/src/remote_worker.c
@@ -24,7 +24,8 @@ int main(int argc, char *const *argv)
 
     amqp_connection_state_t conn;
     amqp_envelope_t envelope;
-    char *host_ip = NULL;
+    char *host = NULL;
+    dcurl_config config = {.broker_host = NULL};
 
     /* Parse the command line options */
     /* TODO: Support macOS since getopt_long() is GNU extension */
@@ -38,13 +39,13 @@ int main(int argc, char *const *argv)
             break;
 
         if (cmd_opt == 'b') {
-            host_ip = optarg;
+            host = optarg;
         }
     }
 
-    dcurl_init();
+    dcurl_init(&config);
 
-    if (!connect_broker(&conn, host_ip))
+    if (!connect_broker(&conn, host))
         goto fail;
 
     if (!declare_queue(&conn, 1, "incoming_queue"))

--- a/tests/test-dcurl.c
+++ b/tests/test-dcurl.c
@@ -59,7 +59,7 @@ int main()
 
     for (int loop_count = 0; loop_count < LOOP_MAX; loop_count++) {
         /* test dcurl Implementation with mwm = 14 */
-        dcurl_init();
+        dcurl_init(NULL);
         int8_t *ret_trytes = dcurl_entry((int8_t *) transaction_trytes, mwm, 8);
         assert(ret_trytes);
         dcurl_destroy();

--- a/tests/test-multi-pow.c
+++ b/tests/test-multi-pow.c
@@ -79,7 +79,7 @@ int main()
     pthread_t threads[THREAD_MAX];
     dcurl_item items[THREAD_MAX];
 
-    dcurl_init();
+    dcurl_init(NULL);
 
     for (int i = 0; i < THREAD_MAX; i++) {
         memcpy(items[i].input_trytes, transaction_trytes, TRANSACTION_TRYTES_LENGTH);


### PR DESCRIPTION
The dcurl_init API can pass a pointer to enable initialization
configuration.
Currently it only sets the hostname of the broker.
If the passed pointer is NULL, the pre-defined default value would be used.

The API document description and the test cases are modified as well.

Close #220.