### PR TITLE
refactor: Rename build option of FPGA

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,7 +1,7 @@
 {
   "hooks": {
     "before:github:release": [
-      "make BUILD_REMOTE=1 BUILD_DEBUG=1 BOARD=de10nano BUILD_FPGA_ACCEL=1",
+      "make BUILD_REMOTE=1 BUILD_DEBUG=1 BOARD=de10nano BUILD_FPGA=1",
       "tar zcvf remote-worker.tar.gz --directory=build remote-worker"
     ]
   },

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ include mk/board.mk
 include mk/docgen.mk
 
 # Assign the hardware to CPU if no hardware is specified
-PLATFORMS := $(BUILD_AVX) $(BUILD_SSE) $(BUILD_GENERIC) $(BUILD_GPU) $(BUILD_FPGA_ACCEL)
+PLATFORMS := $(BUILD_AVX) $(BUILD_SSE) $(BUILD_GENERIC) $(BUILD_GPU) $(BUILD_FPGA)
 ENABLE_PLATFORMS := $(findstring 1,$(PLATFORMS))
 ifneq ("$(ENABLE_PLATFORMS)","1")
     ifeq ("$(call cpu_feature,AVX)","1")
@@ -77,7 +77,7 @@ ifeq ("$(BUILD_GPU)","1")
 include mk/opencl.mk
 endif
 
-ifeq ("$(BUILD_FPGA_ACCEL)","1")
+ifeq ("$(BUILD_FPGA)","1")
 CFLAGS += -DENABLE_FPGA
 endif
 
@@ -151,7 +151,7 @@ OBJS += \
 	compat_ccurl.o
 endif
 
-ifeq ("$(BUILD_FPGA_ACCEL)","1")
+ifeq ("$(BUILD_FPGA)","1")
 OBJS += \
 	pow_fpga.o
 endif

--- a/docs/board-de10-nano.md
+++ b/docs/board-de10-nano.md
@@ -126,7 +126,7 @@ $ git clone git@github.com:DLTcollab/dcurl.git
 ### Build the remote worker
 ```bash
 $ cd dcurl
-$ make BUILD_REMOTE=1 BOARD=de10nano BUILD_FPGA_ACCEL=1
+$ make BUILD_REMOTE=1 BOARD=de10nano BUILD_FPGA=1
 ```
 
 ### Execute the remote worker

--- a/docs/build-n-test.md
+++ b/docs/build-n-test.md
@@ -16,7 +16,7 @@
     - ``BUILD_AVX``: build the Intel AVX-accelerated Curl backend.
     - ``BUILD_SSE``: build the Intel SSE-accelerated Curl backend.
     - ``BUILD_GPU``: build the OpenCL-based GPU accelerations.
-    - ``BUILD_FPGA_ACCEL``: build the interface interacting with the Cyclone V FPGA based accelerator. Verified on DE10-nano board and Arrow SoCKit board.
+    - ``BUILD_FPGA``: build the interface interacting with the Cyclone V FPGA based accelerator. Verified on DE10-nano board and Arrow SoCKit board.
     - ``BUILD_REMOTE``: build with the remote interface and create the remote worker executable for calculating PoW on remote devices.
     - ``BUILD_JNI``: build a JAR file including the shared library and the JAVA bytecode for IRI. The build system would generate JNI header file
                      downloading from [latest JAVA source](https://github.com/DLTcollab/iri).
@@ -105,7 +105,7 @@ Success.
 * Test with Arrow SoCKit board
 ```shell
 $ sh init_curl_pow.sh # set up kernel module
-$ make BUILD_STAT=1 BUILD_FPGA_ACCEL=1 check
+$ make BUILD_STAT=1 BUILD_FPGA=1 check
 ```
 
 * Expected Results

--- a/mk/defs.mk
+++ b/mk/defs.mk
@@ -17,7 +17,7 @@ BUILD_SSE ?= 0
 BUILD_GPU ?= 0
 
 # Build FPGA backend or not
-BUILD_FPGA_ACCEL ?= 0
+BUILD_FPGA ?= 0
 
 # Build facilities of remote procedure calls
 BUILD_REMOTE ?= 0

--- a/mk/static-analysis.mk
+++ b/mk/static-analysis.mk
@@ -39,7 +39,7 @@ static-analysis:
 	  $(MAKE) \
 	    BUILD_AVX=1 \
 	    BUILD_GPU=1 \
-	    BUILD_FPGA_ACCEL=1 \
+	    BUILD_FPGA=1 \
 	    BUILD_REMOTE=1 \
 	    BUILD_JNI=1 \
 	    BUILD_STAT=1


### PR DESCRIPTION
Remove the word '_ACCEL' to unify with the source code.